### PR TITLE
Add startup errors, mention XDG_RUNTIME_DIR in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,10 @@ this process a SIGTERM and wait for it to terminate (if it hasn't already).
 This makes it ideal not only for initialization but also for execing into a
 user-level service manager like s6 or `systemd --user`.
 
+You'll have to explicitly set `XDG_RUNTIME_DIR` if your system doesn't do it for
+you, e.g. `export XDG_RUNTIME_DIR=/tmp/xdg-runtime-$USER && mkdir -p
+$XDG_RUNTIME_DIR`.
+
 More/less verbose output can be requested with flags as well:
 
 * `-q`: quiet (log level WLR_SILENT)

--- a/dwl.c
+++ b/dwl.c
@@ -1074,6 +1074,7 @@ run(char *startup_cmd)
 	const char *socket = wl_display_add_socket_auto(dpy);
 	if (!socket) {
 		wlr_backend_destroy(backend);
+		perror("startup: socket");
 		exit(EXIT_FAILURE);
 	}
 
@@ -1082,6 +1083,7 @@ run(char *startup_cmd)
 	if (!wlr_backend_start(backend)) {
 		wlr_backend_destroy(backend);
 		wl_display_destroy(dpy);
+		perror("startup: backend_start");
 		exit(EXIT_FAILURE);
 	}
 


### PR DESCRIPTION
It was just exiting with code 1 for me. The problem turned out to be
that you *need* to set XDG_RUNTIME_DIR or it won't work (I think e.g.
systemd does that for you, but on Void it's not set by default), so
mention that in the README.