### PR TITLE
Make sure to not pass NULL surfaces to these wlr functions

### DIFF
--- a/dwl.c
+++ b/dwl.c
@@ -907,7 +907,7 @@ pointerfocus(Client *c, struct wlr_surface *surface, double sx, double sy,
 
 	wlr_seat_pointer_notify_enter(seat, surface, sx, sy);
 	/* If keyboard focus follows mouse, enforce that */
-	if (sloppyfocus && surface)
+	if (sloppyfocus)
 		focusclient(c, surface, 0);
 }
 

--- a/dwl.c
+++ b/dwl.c
@@ -595,9 +595,11 @@ focusclient(Client *c, struct wlr_surface *surface, int lift)
 	 * If the focused surface has changed, tell the seat to have the
 	 * keyboard enter the new surface.  wlroots will keep track of this and
 	 * automatically send key events to the appropriate clients.  If surface
-	 * is NULL, this will clear focus.
+	 * is NULL, we clear the focus instead.
 	 */
-	if (surface && (surface != psurface)) {
+	if (!surface) {
+		wlr_seat_pointer_notify_clear_focus(seat);
+	} else if (surface != psurface) {
 		kb = wlr_seat_get_keyboard(seat);
 		wlr_seat_keyboard_notify_enter(seat, surface,
 				kb->keycodes, kb->num_keycodes, &kb->modifiers);

--- a/dwl.c
+++ b/dwl.c
@@ -597,7 +597,7 @@ focusclient(Client *c, struct wlr_surface *surface, int lift)
 	 * automatically send key events to the appropriate clients.  If surface
 	 * is NULL, this will clear focus.
 	 */
-	if (surface != psurface) {
+	if (surface && (surface != psurface)) {
 		kb = wlr_seat_get_keyboard(seat);
 		wlr_seat_keyboard_notify_enter(seat, surface,
 				kb->keycodes, kb->num_keycodes, &kb->modifiers);
@@ -897,8 +897,14 @@ pointerfocus(Client *c, struct wlr_surface *surface, double sx, double sy,
 		wlr_seat_pointer_notify_motion(seat, time, sx, sy);
 		return;
 	}
+
 	/* If surface is NULL, clear pointer focus, otherwise let the client
 	 * know that the mouse cursor has entered one of its surfaces. */
+	if (!surface) {
+		wlr_seat_pointer_notify_clear_focus(seat);
+		return;
+	}
+
 	wlr_seat_pointer_notify_enter(seat, surface, sx, sy);
 	/* If keyboard focus follows mouse, enforce that */
 	if (sloppyfocus && surface)


### PR DESCRIPTION
On my machine passing NULL surfaces resulted in aborts.

I am not sure this is the right way to fix these so you should have a closer look at the issue.