### PR TITLE
Add repeat delay and repeat rate to config.h

### DIFF
--- a/config.def.h
+++ b/config.def.h
@@ -37,6 +37,8 @@ static const struct xkb_rule_names xkb_rules = {
 	.options = "ctrl:nocaps",
 	*/
 };
+static const int repeat_rate = 25;
+static const int repeat_delay = 600;
 
 #define MODKEY WLR_MODIFIER_ALT
 #define TAGKEYS(KEY,SKEY,TAG) \

--- a/dwl.c
+++ b/dwl.c
@@ -391,7 +391,7 @@ createkeyboard(struct wlr_input_device *device)
 	wlr_keyboard_set_keymap(device->keyboard, keymap);
 	xkb_keymap_unref(keymap);
 	xkb_context_unref(context);
-	wlr_keyboard_set_repeat_info(device->keyboard, 25, 600);
+	wlr_keyboard_set_repeat_info(device->keyboard, repeat_rate, repeat_delay);
 
 	/* Here we set up listeners for keyboard events. */
 	kb->modifiers.notify = keypressmod;


### PR DESCRIPTION
Hi and thanks for this cool wm. After switching to sway from dwm, I've been missing something exactly like this (and also a good wayland-port of st). I think it's better to have keyboard repeat rate and -delay available in the config.h instead of hardcoding them in dwl.c, because I really need to change them to feel comfortable on my computer. This PR addresses that.