### PR TITLE
getatom: fix potential uninitialized atom variable

### DIFF
--- a/dwl.c
+++ b/dwl.c
@@ -762,7 +762,7 @@ focusstack(const Arg *arg)
 Atom
 getatom(xcb_connection_t *xc, const char *name)
 {
-	Atom atom;
+	Atom atom = 0;
 	xcb_generic_error_t *error;
 	xcb_intern_atom_cookie_t cookie;
 	xcb_intern_atom_reply_t *reply;


### PR DESCRIPTION
The getatom function returns the atom variable, which is only
initialized in case of a success. This results in a maybe-uninitialized
warning/error. After this commit, now a zero value is returned in case
of error.

~~Furthermore, the getatom calls in the xwaylandready function are now
checked against zero atoms.~~
_(Edit: This was removed; see conversation below)_

Previously, the compilation errors with:
```
dwl.c: In function ‘getatom’:
dwl.c:776:9: error: ‘atom’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
  776 |  return atom;
      |         ^~~~
cc1: all warnings being treated as errors
make: *** [<builtin>: dwl.o] Error 1
```