### PR TITLE
do not render frames when any XDG surface has uncommitted changes

### DIFF
--- a/dwl.c
+++ b/dwl.c
@@ -638,10 +638,11 @@ destroynotify(struct wl_listener *listener, void *data)
 {
 	/* Called when the surface is destroyed and should never be shown again. */
 	Client *c = wl_container_of(listener, c, destroy);
-	wl_list_remove(&c->commit.link);
 	wl_list_remove(&c->map.link);
 	wl_list_remove(&c->unmap.link);
 	wl_list_remove(&c->destroy.link);
+	if (c->type == XDGShell)
+		wl_list_remove(&c->commit.link);
 	free(c);
 }
 
@@ -1247,7 +1248,7 @@ rendermon(struct wl_listener *listener, void *data)
 	{
 		if (c->dirty)
 		{
-			wlr_surface_send_frame_done(c->xdg_surface->surface, &now);
+			wlr_surface_send_frame_done(WLR_SURFACE(c), &now);
 			render = 0;
 		}
 	}

--- a/dwl.c
+++ b/dwl.c
@@ -1244,9 +1244,9 @@ rendermon(struct wl_listener *listener, void *data)
 
 	/* Do not render if clients have uncommitted changes. */
 	wl_list_for_each(c, &stack, slink)
-       	{
+	{
 		if (c->dirty)
-	       	{
+		{
 			wlr_surface_send_frame_done(c->xdg_surface->surface, &now);
 			render = 0;
 		}
@@ -1259,7 +1259,8 @@ rendermon(struct wl_listener *listener, void *data)
 	/* Begin the renderer (calls glViewport and some other GL sanity checks) */
 	wlr_renderer_begin(drw, m->wlr_output->width, m->wlr_output->height);
 
-	if (render) {
+	if (render)
+	{
 		wlr_renderer_clear(drw, rootcolor);
 
 		renderclients(m, &now);

--- a/dwl.c
+++ b/dwl.c
@@ -1243,10 +1243,10 @@ rendermon(struct wl_listener *listener, void *data)
 	struct timespec now;
 	clock_gettime(CLOCK_MONOTONIC, &now);
 
-	/* Do not render if clients have uncommitted changes. */
+	/* Do not render if XDG clients have uncommitted changes. */
 	wl_list_for_each(c, &stack, slink)
 	{
-		if (c->dirty)
+		if (c->type == XDGShell && c->dirty)
 		{
 			wlr_surface_send_frame_done(WLR_SURFACE(c), &now);
 			render = 0;
@@ -1295,6 +1295,7 @@ resize(Client *c, int x, int y, int w, int h, int interact)
 	c->geom.y = y;
 	c->geom.width = w;
 	c->geom.height = h;
+	c->dirty = 1;
 	applybounds(c, bbox);
 	/* wlroots makes this a no-op if size hasn't changed */
 	if (c->type != XDGShell)


### PR DESCRIPTION
~~This is not a complete solution. We can use this mechanism to skip more frames as we discover means of detecting them.~~

~~The commit handler is picking up the uncommitted changes when creating a new client, however does not see other changes such as a master width resize.~~

Update: This change is complete, for XDG clients only. Resizes are aggressively marked as dirty, and skip rendering until all the changes have been committed.

Such a solution cannot work for X.