### PR TITLE
 Define SHCMD macro

### DIFF
--- a/config.def.h
+++ b/config.def.h
@@ -49,6 +49,8 @@ static const int repeat_delay = 600;
 	{ MODKEY|WLR_MODIFIER_SHIFT, SKEY,           tag,             {.ui = 1 << TAG} }, \
 	{ MODKEY|WLR_MODIFIER_CTRL|WLR_MODIFIER_SHIFT,SKEY,toggletag, {.ui = 1 << TAG} }
 
+#define SHCMD(cmd) { .v = (const char*[]){ "/bin/sh", "-c", cmd, NULL } }
+
 /* commands */
 static const char *termcmd[]  = { "alacritty", NULL };
 


### PR DESCRIPTION
I don't know if this was intentionally left out but defining a function for every non-dwm keybinding would be painfully verbose.