### PR TITLE
Fullscreen support

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,6 @@ dwl is a work in progress, and it has not yet reached its feature goals in a num
 - Statusbar support (built-in or external)
 - layer-shell
 - Damage tracking
-- Fullscreen/fixed windows (or whatever the Wayland analogues are)
 
 
 ## Acknowledgements

--- a/config.def.h
+++ b/config.def.h
@@ -75,6 +75,7 @@ static const Key keys[] = {
 	{ MODKEY,                    XKB_KEY_m,          setlayout,      {.v = &layouts[2]} },
 	{ MODKEY,                    XKB_KEY_space,      setlayout,      {0} },
 	{ MODKEY|WLR_MODIFIER_SHIFT, XKB_KEY_space,      togglefloating, {0} },
+	{ MODKEY, 					 XKB_KEY_e,    		togglefullscreen, {0} },
 	{ MODKEY,                    XKB_KEY_0,          view,           {.ui = ~0} },
 	{ MODKEY|WLR_MODIFIER_SHIFT, XKB_KEY_parenright, tag,            {.ui = ~0} },
 	{ MODKEY,                    XKB_KEY_comma,      focusmon,       {.i = -1} },

--- a/dwl.c
+++ b/dwl.c
@@ -1241,27 +1241,26 @@ renderclients(Monitor *m, struct timespec *now)
 		ox = c->geom.x, oy = c->geom.y;
 		wlr_output_layout_output_coords(output_layout, m->wlr_output,
 				&ox, &oy);
-		if (c->bw == 0)
-			goto render;
 
-		w = surface->current.width;
-		h = surface->current.height;
-		borders = (struct wlr_box[4]) {
-			{ox, oy, w + 2 * c->bw, c->bw},             /* top */
-			{ox, oy + c->bw, c->bw, h},                 /* left */
-			{ox + c->bw + w, oy + c->bw, c->bw, h},     /* right */
-			{ox, oy + c->bw + h, w + 2 * c->bw, c->bw}, /* bottom */
-		};
+		if (c->bw) {
+			w = surface->current.width;
+			h = surface->current.height;
+			borders = (struct wlr_box[4]) {
+				{ox, oy, w + 2 * c->bw, c->bw},             /* top */
+				{ox, oy + c->bw, c->bw, h},                 /* left */
+				{ox + c->bw + w, oy + c->bw, c->bw, h},     /* right */
+				{ox, oy + c->bw + h, w + 2 * c->bw, c->bw}, /* bottom */
+			};
 
-		/* Draw window borders */
-		color = (c == sel) ? focuscolor : bordercolor;
-		for (i = 0; i < 4; i++) {
-			scalebox(&borders[i], m->wlr_output->scale);
-			wlr_render_rect(drw, &borders[i], color,
-					m->wlr_output->transform_matrix);
+			/* Draw window borders */
+			color = (c == sel) ? focuscolor : bordercolor;
+			for (i = 0; i < 4; i++) {
+				scalebox(&borders[i], m->wlr_output->scale);
+				wlr_render_rect(drw, &borders[i], color,
+						m->wlr_output->transform_matrix);
+			}
 		}
 
-render:
 		/* This calls our render function for each surface among the
 		 * xdg_surface's toplevel and popups. */
 		rdata.output = m->wlr_output;

--- a/dwl.c
+++ b/dwl.c
@@ -110,7 +110,7 @@ typedef struct {
 	int prevy;
 	int prevwidth;
 	int prevheight;
-	bool isfullscreen;
+	int isfullscreen;
 } Client;
 
 typedef struct {
@@ -608,7 +608,7 @@ createnotify(struct wl_listener *listener, void *data)
 
 	c->fullscreen.notify = fullscreenotify;
 	wl_signal_add(&xdg_surface->toplevel->events.request_fullscreen, &c->fullscreen);
-	c->isfullscreen = false;
+	c->isfullscreen = 0;
 }
 
 void
@@ -677,7 +677,8 @@ destroyxdeco(struct wl_listener *listener, void *data)
 }
 
 void
-fullscreenotify(struct wl_listener *listener, void *data) {
+fullscreenotify(struct wl_listener *listener, void *data)
+{
 	Client *c = wl_container_of(listener, c, fullscreen);
 	c->isfullscreen = !c->isfullscreen;
 
@@ -1858,7 +1859,7 @@ createnotifyx11(struct wl_listener *listener, void *data)
 
 	c->fullscreen.notify = fullscreenotify;
 	wl_signal_add(&xwayland_surface->events.request_fullscreen, &c->fullscreen);
-	c->isfullscreen = false;
+	c->isfullscreen = 0;
 }
 
 Atom

--- a/dwl.c
+++ b/dwl.c
@@ -96,6 +96,7 @@ typedef struct {
 	struct wl_listener map;
 	struct wl_listener unmap;
 	struct wl_listener destroy;
+	struct wl_listener fullscreen;
 	struct wlr_box geom;  /* layout-relative, includes border */
 	Monitor *mon;
 #ifdef XWAYLAND
@@ -192,6 +193,7 @@ static void createxdeco(struct wl_listener *listener, void *data);
 static void cursorframe(struct wl_listener *listener, void *data);
 static void destroynotify(struct wl_listener *listener, void *data);
 static void destroyxdeco(struct wl_listener *listener, void *data);
+static void fullscreenotify(struct wl_listener *listener, void *data);
 static Monitor *dirtomon(int dir);
 static void focusclient(Client *old, Client *c, int lift);
 static void focusmon(const Arg *arg);
@@ -598,6 +600,9 @@ createnotify(struct wl_listener *listener, void *data)
 	wl_signal_add(&xdg_surface->events.unmap, &c->unmap);
 	c->destroy.notify = destroynotify;
 	wl_signal_add(&xdg_surface->events.destroy, &c->destroy);
+
+	wl_signal_add(&xdg_surface->toplevel->events.request_fullscreen, &c->fullscreen);
+	c->fullscreen.notify = fullscreenotify;
 }
 
 void
@@ -662,6 +667,12 @@ destroyxdeco(struct wl_listener *listener, void *data)
 	wl_list_remove(&d->destroy.link);
 	wl_list_remove(&d->request_mode.link);
 	free(d);
+}
+
+void
+fullscreenotify(struct wl_listener *listener, void *data) {
+	Client *c = wl_container_of(listener, c, fullscreen);
+	wlr_xdg_toplevel_set_fullscreen(c->surface.xdg, true);
 }
 
 Monitor *

--- a/dwl.c
+++ b/dwl.c
@@ -588,7 +588,6 @@ createnotify(struct wl_listener *listener, void *data)
 
 	if (xdg_surface->role != WLR_XDG_SURFACE_ROLE_TOPLEVEL)
 		return;
-
 	wl_list_for_each(c, &clients, link)
 		if (c->isfullscreen && VISIBLEON(c, c->mon))
 			setfullscreen(c, 0);
@@ -1242,7 +1241,7 @@ renderclients(Monitor *m, struct timespec *now)
 		wlr_output_layout_output_coords(output_layout, m->wlr_output,
 				&ox, &oy);
 
-		if (c->isfullscreen || borderpx == 0)
+		if (c->isfullscreen)
 			goto render;
 
 		w = surface->current.width;
@@ -1866,13 +1865,15 @@ createnotifyx11(struct wl_listener *listener, void *data)
 {
 	struct wlr_xwayland_surface *xwayland_surface = data;
 	Client *c;
+	wl_list_for_each(c, &clients, link)
+		if (c->isfullscreen && VISIBLEON(c, c->mon))
+			setfullscreen(c, 0);
 
 	/* Allocate a Client for this surface */
 	c = xwayland_surface->data = calloc(1, sizeof(*c));
 	c->surface.xwayland = xwayland_surface;
 	c->type = xwayland_surface->override_redirect ? X11Unmanaged : X11Managed;
 	c->bw = borderpx;
-	quitfullscreen(c);
 
 	/* Listen to the various events it can emit */
 	c->map.notify = maprequest;

--- a/dwl.c
+++ b/dwl.c
@@ -232,6 +232,7 @@ static void setcursor(struct wl_listener *listener, void *data);
 static void setpsel(struct wl_listener *listener, void *data);
 static void setsel(struct wl_listener *listener, void *data);
 static void setfloating(Client *c, int floating);
+static void setfullscreen(Client *c, int fullscreen);
 static void setlayout(const Arg *arg);
 static void setmfact(const Arg *arg);
 static void setmon(Client *c, Monitor *m, unsigned int newtags);
@@ -242,6 +243,7 @@ static void tag(const Arg *arg);
 static void tagmon(const Arg *arg);
 static void tile(Monitor *m);
 static void togglefloating(const Arg *arg);
+static void togglefullscreen(const Arg *arg);
 static void toggletag(const Arg *arg);
 static void toggleview(const Arg *arg);
 static void unmapnotify(struct wl_listener *listener, void *data);
@@ -696,10 +698,16 @@ destroyxdeco(struct wl_listener *listener, void *data)
 }
 
 void
-fullscreenotify(struct wl_listener *listener, void *data)
+togglefullscreen(const Arg *arg)
 {
-	Client *c = wl_container_of(listener, c, fullscreen);
-	c->isfullscreen = !c->isfullscreen;
+	Client *sel = selclient();
+	setfullscreen(sel, !sel->isfullscreen);
+}
+
+void
+setfullscreen(Client *c, int fullscreen)
+{
+	c->isfullscreen = fullscreen;
 
 #ifdef XWAYLAND
 	if (c->type == X11Managed)
@@ -718,6 +726,13 @@ fullscreenotify(struct wl_listener *listener, void *data)
 	} else {
 		resize(c, c->prevx, c->prevy, c->prevwidth, c->prevheight, 0);
 	}
+}
+
+void
+fullscreenotify(struct wl_listener *listener, void *data)
+{
+	Client *c = wl_container_of(listener, c, fullscreen);
+	setfullscreen(c, !c->isfullscreen);
 }
 
 Monitor *

--- a/dwl.c
+++ b/dwl.c
@@ -722,7 +722,7 @@ setfullscreen(Client *c, int fullscreen)
 		c->prevy = c->geom.y;
 		c->prevheight = c->geom.height;
 		c->prevwidth = c->geom.width;
-		resize(c, c->mon->w.x, c->mon->w.y, c->mon->w.width, c->mon->w.height, 0);
+		resize(c, c->mon->m.x, c->mon->m.y, c->mon->m.width, c->mon->m.height, 0);
 	} else {
 		resize(c, c->prevx, c->prevy, c->prevwidth, c->prevheight, 0);
 	}

--- a/dwl.c
+++ b/dwl.c
@@ -217,7 +217,6 @@ static void motionabsolute(struct wl_listener *listener, void *data);
 static void motionnotify(uint32_t time);
 static void motionrelative(struct wl_listener *listener, void *data);
 static void moveresize(const Arg *arg);
-static void quitfullscreen(Client *c);
 static void pointerfocus(Client *c, struct wlr_surface *surface,
 		double sx, double sy, uint32_t time);
 static void quit(const Arg *arg);
@@ -580,24 +579,6 @@ createmon(struct wl_listener *listener, void *data)
 }
 
 void
-quitfullscreen(Client *c)
-{
-	wl_list_for_each(c, &clients, link) {
-		if (c->isfullscreen && VISIBLEON(c, c->mon)) {
-#ifdef XWAYLAND
-			if (c->type == X11Managed)
-				wlr_xwayland_surface_set_fullscreen(c->surface.xwayland, false);
-			else
-#endif
-				wlr_xdg_toplevel_set_fullscreen(c->surface.xdg, false);
-			c->bw = borderpx;
-			resize(c, c->prevx, c->prevy, c->prevwidth, c->prevheight, 0);
-			c->isfullscreen = 0;
-		}
-	}
-}
-
-void
 createnotify(struct wl_listener *listener, void *data)
 {
 	/* This event is raised when wlr_xdg_shell receives a new xdg surface from a
@@ -608,11 +589,14 @@ createnotify(struct wl_listener *listener, void *data)
 	if (xdg_surface->role != WLR_XDG_SURFACE_ROLE_TOPLEVEL)
 		return;
 
+	wl_list_for_each(c, &clients, link)
+		if (c->isfullscreen && VISIBLEON(c, c->mon))
+			setfullscreen(c, 0);
+
 	/* Allocate a Client for this surface */
 	c = xdg_surface->data = calloc(1, sizeof(*c));
 	c->surface.xdg = xdg_surface;
 	c->bw = borderpx;
-	quitfullscreen(c);
 
 	/* Tell the client not to try anything fancy */
 	wlr_xdg_toplevel_set_tiled(c->surface.xdg, WLR_EDGE_TOP |

--- a/dwl.c
+++ b/dwl.c
@@ -672,7 +672,9 @@ destroyxdeco(struct wl_listener *listener, void *data)
 void
 fullscreenotify(struct wl_listener *listener, void *data) {
 	Client *c = wl_container_of(listener, c, fullscreen);
-	wlr_xdg_toplevel_set_fullscreen(c->surface.xdg, !c->surface.xdg->toplevel->current.fullscreen);
+	wlr_xdg_toplevel_set_fullscreen(
+			c->surface.xdg, !c->surface.xdg->toplevel->current.fullscreen);
+	c->bw = (int)c->surface.xdg->toplevel->current.fullscreen * borderpx;
 }
 
 Monitor *
@@ -1193,6 +1195,10 @@ renderclients(Monitor *m, struct timespec *now)
 		ox = c->geom.x, oy = c->geom.y;
 		wlr_output_layout_output_coords(output_layout, m->wlr_output,
 				&ox, &oy);
+
+		if (c->bw == 0)
+			goto render;
+
 		w = surface->current.width;
 		h = surface->current.height;
 		borders = (struct wlr_box[4]) {
@@ -1210,6 +1216,7 @@ renderclients(Monitor *m, struct timespec *now)
 					m->wlr_output->transform_matrix);
 		}
 
+ render:
 		/* This calls our render function for each surface among the
 		 * xdg_surface's toplevel and popups. */
 		rdata.output = m->wlr_output;

--- a/dwl.c
+++ b/dwl.c
@@ -708,16 +708,16 @@ void
 setfullscreen(Client *c, int fullscreen)
 {
 	c->isfullscreen = fullscreen;
+	c->bw = (1 - fullscreen) * borderpx;
 
 #ifdef XWAYLAND
 	if (c->type == X11Managed)
-		wlr_xwayland_surface_set_fullscreen(c->surface.xwayland, c->isfullscreen);
+		wlr_xwayland_surface_set_fullscreen(c->surface.xwayland, fullscreen);
 	else
 #endif
-		wlr_xdg_toplevel_set_fullscreen(c->surface.xdg, c->isfullscreen);
+		wlr_xdg_toplevel_set_fullscreen(c->surface.xdg, fullscreen);
 
-	c->bw = ((int)(!c->isfullscreen)) * borderpx;
-	if (c->isfullscreen) {
+	if (fullscreen) {
 		c->prevx = c->geom.x;
 		c->prevy = c->geom.y;
 		c->prevheight = c->geom.height;

--- a/dwl.c
+++ b/dwl.c
@@ -1017,6 +1017,10 @@ monocle(Monitor *m)
 	wl_list_for_each(c, &clients, link) {
 		if (!VISIBLEON(c, m) || c->isfloating)
 			continue;
+		if (c->isfullscreen) {
+			resize(c, c->mon->m.x, c->mon->m.y, c->mon->m.width, c->mon->m.height, 0);
+			return;
+		}
 		resize(c, m->w.x, m->w.y, m->w.width, m->w.height, 0);
 	}
 }
@@ -1728,6 +1732,10 @@ tile(Monitor *m)
 	wl_list_for_each(c, &clients, link) {
 		if (!VISIBLEON(c, m) || c->isfloating)
 			continue;
+		if (c->isfullscreen) {
+			resize(c, c->mon->m.x, c->mon->m.y, c->mon->m.width, c->mon->m.height, 0);
+			return;
+		}
 		if (i < m->nmaster) {
 			h = (m->w.height - my) / (MIN(n, m->nmaster) - i);
 			resize(c, m->w.x, m->w.y + my, mw, h, 0);

--- a/dwl.c
+++ b/dwl.c
@@ -294,7 +294,6 @@ static struct wl_listener request_set_sel = {.notify = setsel};
 #ifdef XWAYLAND
 static void activatex11(struct wl_listener *listener, void *data);
 static void createnotifyx11(struct wl_listener *listener, void *data);
-static void fullscreenotifyx11(struct wl_listener *listener, void *data);
 static Atom getatom(xcb_connection_t *xc, const char *name);
 static void renderindependents(struct wlr_output *output, struct timespec *now);
 static void updatewindowtype(Client *c);
@@ -609,6 +608,7 @@ createnotify(struct wl_listener *listener, void *data)
 
 	c->fullscreen.notify = fullscreenotify;
 	wl_signal_add(&xdg_surface->toplevel->events.request_fullscreen, &c->fullscreen);
+	c->isfullscreen = false;
 }
 
 void
@@ -679,18 +679,24 @@ destroyxdeco(struct wl_listener *listener, void *data)
 void
 fullscreenotify(struct wl_listener *listener, void *data) {
 	Client *c = wl_container_of(listener, c, fullscreen);
-	wlr_xdg_toplevel_set_fullscreen(
-			c->surface.xdg, !c->surface.xdg->toplevel->current.fullscreen);
-	c->bw = (int)c->surface.xdg->toplevel->current.fullscreen * borderpx;
+	c->isfullscreen = !c->isfullscreen;
 
-	if (c->surface.xdg->toplevel->current.fullscreen) { /* fullscreen off */
-		resize(c, c->prevx, c->prevy, c->prevwidth, c->prevheight, 0);
-	} else { /* fullscreen on */
+#ifdef XWAYLAND
+	if (c->type == X11Managed)
+		wlr_xwayland_surface_set_fullscreen(c->surface.xwayland, c->isfullscreen);
+	else
+#endif
+		wlr_xdg_toplevel_set_fullscreen(c->surface.xdg, c->isfullscreen);
+
+	c->bw = ((int)(!c->isfullscreen)) * borderpx;
+	if (c->isfullscreen) {
 		c->prevx = c->geom.x;
 		c->prevy = c->geom.y;
 		c->prevheight = c->geom.height;
 		c->prevwidth = c->geom.width;
 		resize(c, c->mon->w.x, c->mon->w.y, c->mon->w.width, c->mon->w.height, 0);
+	} else {
+		resize(c, c->prevx, c->prevy, c->prevwidth, c->prevheight, 0);
 	}
 }
 
@@ -1850,33 +1856,9 @@ createnotifyx11(struct wl_listener *listener, void *data)
 	c->destroy.notify = destroynotify;
 	wl_signal_add(&xwayland_surface->events.destroy, &c->destroy);
 
-	c->fullscreen.notify = fullscreenotifyx11;
+	c->fullscreen.notify = fullscreenotify;
 	wl_signal_add(&xwayland_surface->events.request_fullscreen, &c->fullscreen);
 	c->isfullscreen = false;
-}
-
-void
-fullscreenotifyx11(struct wl_listener *listener, void *data) {
-	FILE *xway = fopen("/tmp/dwl/xway", "a");
-    Client *c;
-	c = wl_container_of(listener, c, fullscreen);
-	c->isfullscreen = !c->isfullscreen;
-	wlr_xwayland_surface_set_fullscreen(
-			c->surface.xwayland, c->isfullscreen);
-	c->bw = ((int)(!c->isfullscreen)) * borderpx;
-
-	fprintf(xway, "fullscreen: %d\n", c->surface.xwayland->fullscreen);
-	fclose(xway);
-
-	if (c->isfullscreen) { /* fullscreen off */
-		c->prevx = c->geom.x;
-		c->prevy = c->geom.y;
-		c->prevheight = c->geom.height;
-		c->prevwidth = c->geom.width;
-		resize(c, c->mon->w.x, c->mon->w.y, c->mon->w.width, c->mon->w.height, 0);
-	} else { /* fullscreen on */
-		resize(c, c->prevx, c->prevy, c->prevwidth, c->prevheight, 1);
-	}
 }
 
 Atom

--- a/dwl.c
+++ b/dwl.c
@@ -653,6 +653,7 @@ destroynotify(struct wl_listener *listener, void *data)
 	wl_list_remove(&c->map.link);
 	wl_list_remove(&c->unmap.link);
 	wl_list_remove(&c->destroy.link);
+	wl_list_remove(&c->fullscreen.link);
 #ifdef XWAYLAND
 	if (c->type == X11Managed)
 		wl_list_remove(&c->activate.link);

--- a/dwl.c
+++ b/dwl.c
@@ -672,7 +672,7 @@ destroyxdeco(struct wl_listener *listener, void *data)
 void
 fullscreenotify(struct wl_listener *listener, void *data) {
 	Client *c = wl_container_of(listener, c, fullscreen);
-	wlr_xdg_toplevel_set_fullscreen(c->surface.xdg, true);
+	wlr_xdg_toplevel_set_fullscreen(c->surface.xdg, !c->surface.xdg->toplevel->current.fullscreen);
 }
 
 Monitor *

--- a/dwl.c
+++ b/dwl.c
@@ -1254,7 +1254,7 @@ renderclients(Monitor *m, struct timespec *now)
 		wlr_output_layout_output_coords(output_layout, m->wlr_output,
 				&ox, &oy);
 
-		if (c->bw == 0)
+		if (c->isfullscreen || borderpx == 0)
 			goto render;
 
 		w = surface->current.width;
@@ -1274,7 +1274,7 @@ renderclients(Monitor *m, struct timespec *now)
 					m->wlr_output->transform_matrix);
 		}
 
- render:
+render:
 		/* This calls our render function for each surface among the
 		 * xdg_surface's toplevel and popups. */
 		rdata.output = m->wlr_output;

--- a/dwl.c
+++ b/dwl.c
@@ -700,6 +700,7 @@ setfullscreen(Client *c, int fullscreen)
 #endif
 		wlr_xdg_toplevel_set_fullscreen(c->surface.xdg, fullscreen);
 
+	// restore previous size instead of arrange to work with floating windows
 	if (fullscreen) {
 		c->prevx = c->geom.x;
 		c->prevy = c->geom.y;
@@ -1240,8 +1241,7 @@ renderclients(Monitor *m, struct timespec *now)
 		ox = c->geom.x, oy = c->geom.y;
 		wlr_output_layout_output_coords(output_layout, m->wlr_output,
 				&ox, &oy);
-
-		if (c->isfullscreen)
+		if (c->bw == 0)
 			goto render;
 
 		w = surface->current.width;

--- a/dwl.c
+++ b/dwl.c
@@ -106,6 +106,10 @@ typedef struct {
 	unsigned int tags;
 	int isfloating;
 	uint32_t resize; /* configure serial of a pending resize */
+	int prevx;
+	int prevy;
+	int prevwidth;
+	int prevheight;
 } Client;
 
 typedef struct {
@@ -675,6 +679,16 @@ fullscreenotify(struct wl_listener *listener, void *data) {
 	wlr_xdg_toplevel_set_fullscreen(
 			c->surface.xdg, !c->surface.xdg->toplevel->current.fullscreen);
 	c->bw = (int)c->surface.xdg->toplevel->current.fullscreen * borderpx;
+
+	if (c->surface.xdg->toplevel->current.fullscreen) { /* fullscreen off */
+		resize(c, c->prevx, c->prevy, c->prevwidth, c->prevheight, 0);
+	} else { /* fullscreen on */
+		c->prevx = c->geom.x;
+		c->prevy = c->geom.y;
+		c->prevheight = c->geom.height;
+		c->prevwidth = c->geom.width;
+		resize(c, c->mon->w.x, c->mon->w.y, c->mon->w.width, c->mon->w.height, 0);
+	}
 }
 
 Monitor *


### PR DESCRIPTION
A client can be set fullscreen in two ways:

+ From the client itself (playing a video in fullscreen on a browser or trough a shortcut built into the client)
+ From dwl with ``mod + e`` (works on all clients)

The server tells the client to lose its fullscreen status when a new client is added to the same tag. Instead, if it is moved to a different tag where there already are other clients, it keeps it fullscreen status (no titlebar...) while still being resized to fit in the new tag's layout. Since this situation is a quite rare and can easily fixed with another fullscreen toggle, I don't feel like it is a major inconvenience.

Among all the clients I tested (various qt and gtk applications for wayland, dia and steam for xwayland) the only one who doesn't play nicely with server imposed fullscreen is firefox (wayland) and I still don't understand why. It works perfectly when using f11 though.

By the way, this is an awesome project! When the layer shell protocol and fullscreen support will be completed I'll completely move from sway to dwl as a daily driver.