### PR TITLE
Add install target to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,5 +33,10 @@ dwl: xdg-shell-protocol.o
 clean:
 	rm -f dwl *.o xdg-shell-protocol.h xdg-shell-protocol.c
 
+install: dwl
+	mkdir -p $(PREFIX)/bin
+	cp -f dwl $(PREFIX)/bin
+	chmod 755 $(PREFIX)/bin/dwl
+
 .DEFAULT_GOAL=dwl
 .PHONY: clean

--- a/config.mk
+++ b/config.mk
@@ -1,3 +1,6 @@
+# paths
+PREFIX = /usr/local
+
 # Default compile flags (overridable by environment)
 CFLAGS ?= -g -Wall -Wextra -Werror -Wno-unused-parameter -Wno-sign-compare -Wno-error=unused-function
 


### PR DESCRIPTION
Adds a method for easy installation. `$PREFIX` is set in `config.mk`.