### PR TITLE
fix undeclared WLR_KEY_PRESSED

### DIFF
--- a/dwl.c
+++ b/dwl.c
@@ -856,7 +856,7 @@ keypress(struct wl_listener *listener, void *data)
 	int handled = 0;
 	uint32_t mods = wlr_keyboard_get_modifiers(kb->device->keyboard);
 	/* On _press_, attempt to process a compositor keybinding. */
-	if (event->state == WLR_KEY_PRESSED)
+	if (event->state == WL_KEYBOARD_KEY_STATE_PRESSED)
 		for (i = 0; i < nsyms; i++)
 			handled = keybinding(mods, syms[i]) || handled;
 


### PR DESCRIPTION
hi, not sure if this is correct or not, but I was unable to compile latest dwl with latest wlroots, this patch is a total guess, but dwl is at least running on my system now

thanks,
richard