### PR TITLE
Define monitor's x,y at compile time

### DIFF
--- a/config.def.h
+++ b/config.def.h
@@ -28,12 +28,14 @@ static const Layout layouts[] = {
  * The order in which monitors are defined determines their position.
  * Non-configured monitors are always added to the left. */
 static const MonitorRule monrules[] = {
-	/* name       mfact nmaster scale layout       rotate/reflect */
+	/* name       mfact nmaster scale layout       rotate/reflect x y */
 	/* example of a HiDPI laptop monitor:
-	{ "eDP-1",    0.5,  1,      2,    &layouts[0], WL_OUTPUT_TRANSFORM_NORMAL },
+	{ "eDP-1",    0.5,  1,      2,    &layouts[0], WL_OUTPUT_TRANSFORM_NORMAL, 0, 0 },
 	*/
+	/* the order in which monitors are defined here affects the order in which
+	 * focusmon and tagmon cycle trough the monitors */
 	/* defaults */
-	{ NULL,       0.55, 1,      1,    &layouts[0], WL_OUTPUT_TRANSFORM_NORMAL },
+	{ NULL,       0.55, 1,      1,    &layouts[0], WL_OUTPUT_TRANSFORM_NORMAL, 0, 0 },
 };
 
 /* keyboard */


### PR DESCRIPTION
Replaces the outputOrder patch.

This avoids recalculating positions and allows to arrange monitors in
any order, not just from left to right.

The order in which monitors are defined in config.h still matters but
it's just the order in the list, not the actual position.

See #71 