### PR TITLE
Determine monitor order spatially

### DIFF
--- a/config.def.h
+++ b/config.def.h
@@ -32,8 +32,6 @@ static const MonitorRule monrules[] = {
 	/* example of a HiDPI laptop monitor:
 	{ "eDP-1",    0.5,  1,      2,    &layouts[0], WL_OUTPUT_TRANSFORM_NORMAL, 0, 0 },
 	*/
-	/* the order in which monitors are defined here affects the order in which
-	 * focusmon and tagmon cycle trough the monitors */
 	/* defaults */
 	{ NULL,       0.55, 1,      1,    &layouts[0], WL_OUTPUT_TRANSFORM_NORMAL, 0, 0 },
 };
@@ -87,10 +85,10 @@ static const Key keys[] = {
 	{ MODKEY, 					 XKB_KEY_e,    		togglefullscreen, {0} },
 	{ MODKEY,                    XKB_KEY_0,          view,           {.ui = ~0} },
 	{ MODKEY|WLR_MODIFIER_SHIFT, XKB_KEY_parenright, tag,            {.ui = ~0} },
-	{ MODKEY,                    XKB_KEY_comma,      focusmon,       {.i = -1} },
-	{ MODKEY,                    XKB_KEY_period,     focusmon,       {.i = +1} },
-	{ MODKEY|WLR_MODIFIER_SHIFT, XKB_KEY_less,       tagmon,         {.i = -1} },
-	{ MODKEY|WLR_MODIFIER_SHIFT, XKB_KEY_greater,    tagmon,         {.i = +1} },
+	{ MODKEY,                    XKB_KEY_comma,      focusmon,       {.i = WLR_DIRECTION_LEFT} },
+	{ MODKEY,                    XKB_KEY_period,     focusmon,       {.i = WLR_DIRECTION_RIGHT} },
+	{ MODKEY|WLR_MODIFIER_SHIFT, XKB_KEY_less,       tagmon,         {.i = WLR_DIRECTION_LEFT} },
+	{ MODKEY|WLR_MODIFIER_SHIFT, XKB_KEY_greater,    tagmon,         {.i = WLR_DIRECTION_RIGHT} },
 	TAGKEYS(          XKB_KEY_1, XKB_KEY_exclam,                     0),
 	TAGKEYS(          XKB_KEY_2, XKB_KEY_at,                         1),
 	TAGKEYS(          XKB_KEY_3, XKB_KEY_numbersign,                 2),

--- a/dwl.c
+++ b/dwl.c
@@ -235,7 +235,7 @@ static void cursorframe(struct wl_listener *listener, void *data);
 static void destroylayersurfacenotify(struct wl_listener *listener, void *data);
 static void destroynotify(struct wl_listener *listener, void *data);
 static void destroyxdeco(struct wl_listener *listener, void *data);
-static Monitor *dirtomon(int dir);
+static Monitor *dirtomon(enum wlr_direction dir);
 static void focusclient(Client *c, int lift);
 static void focusmon(const Arg *arg);
 static void focusstack(const Arg *arg);
@@ -1096,19 +1096,17 @@ fullscreennotify(struct wl_listener *listener, void *data)
 }
 
 Monitor *
-dirtomon(int dir)
+dirtomon(enum wlr_direction dir)
 {
-	Monitor *m;
-
-	if (dir > 0) {
-		if (selmon->link.next == &mons)
-			return wl_container_of(mons.next, m, link);
-		return wl_container_of(selmon->link.next, m, link);
-	} else {
-		if (selmon->link.prev == &mons)
-			return wl_container_of(mons.prev, m, link);
-		return wl_container_of(selmon->link.prev, m, link);
-	}
+	struct wlr_output *next;
+	if ((next = wlr_output_layout_adjacent_output(output_layout,
+			dir, selmon->wlr_output, selmon->m.x, selmon->m.y)))
+		return next->data;
+	if ((next = wlr_output_layout_farthest_output(output_layout,
+			dir ^ (WLR_DIRECTION_LEFT|WLR_DIRECTION_RIGHT),
+			selmon->wlr_output, selmon->m.x, selmon->m.y)))
+		return next->data;
+	return selmon;
 }
 
 void

--- a/dwl.c
+++ b/dwl.c
@@ -176,7 +176,6 @@ struct Monitor {
 	double mfact;
 	int nmaster;
 	Client *fullscreenclient;
-	int position;
 };
 
 typedef struct {
@@ -830,7 +829,6 @@ createmon(struct wl_listener *listener, void *data)
 	m = wlr_output->data = calloc(1, sizeof(*m));
 	m->wlr_output = wlr_output;
 	m->tagset[0] = m->tagset[1] = 1;
-	m->position = -1;
 	for (r = monrules; r < END(monrules); r++) {
 		if (!r->name || strstr(wlr_output->name, r->name)) {
 			m->mfact = r->mfact;
@@ -839,7 +837,6 @@ createmon(struct wl_listener *listener, void *data)
 			wlr_xcursor_manager_load(cursor_mgr, r->scale);
 			m->lt[0] = m->lt[1] = r->lt;
 			wlr_output_set_transform(wlr_output, r->rr);
-			m->position = r - monrules;
 			break;
 		}
 	}
@@ -848,15 +845,7 @@ createmon(struct wl_listener *listener, void *data)
 	LISTEN(&wlr_output->events.frame, &m->frame, rendermon);
 	LISTEN(&wlr_output->events.destroy, &m->destroy, cleanupmon);
 
-	wl_list_for_each(moni, &mons, link)
-		if (m->position > moni->position)
-			insertmon = moni;
-
-	if (insertmon) /* insertmon is the leftmost monitor to m */
-		wl_list_insert(&insertmon->link, &m->link);
-	else
-		wl_list_insert(&mons, &m->link);
-
+	wl_list_insert(&mons, &m->link);
 	wlr_output_enable(wlr_output, 1);
 	if (!wlr_output_commit(wlr_output))
 		return;


### PR DESCRIPTION
Cycling through monitors in left-to-right/right-to-left order is reasonable behavior, and wlroots already provides this functionality, so let's not reimplement anything we don't have to.

This should make it easier to bring back autoconfigured outputs.  It has the added benefit of putting the output-order logic in a single, well-defined location (easily hackable/patchable!) for anyone who prefers a different default.
