### PR TITLE
Fix Initialization of NetWM Atoms

### DIFF
--- a/dwl.c
+++ b/dwl.c
@@ -320,8 +320,10 @@ static struct wlr_virtual_keyboard_manager_v1 *virtual_keyboard_mgr;
 
 static struct wlr_cursor *cursor;
 static struct wlr_xcursor_manager *cursor_mgr;
+#ifdef XWAYLAND
 static struct wlr_xcursor *xcursor;
 static struct wlr_xcursor_manager *xcursor_mgr;
+#endif
 
 static struct wlr_seat *seat;
 static struct wl_list keyboards;
@@ -2517,8 +2519,8 @@ xwaylandready(struct wl_listener *listener, void *data)
 	 * not detect that window type. */
 	netatom[NetWMWindowTypeDialog] = getatom(xc, "_NET_WM_WINDOW_TYPE_DIALOG");
 	netatom[NetWMWindowTypeSplash] = getatom(xc, "_NET_WM_WINDOW_TYPE_SPLASH");
-	netatom[NetWMWindowTypeUtility] = getatom(xc, "_NET_WM_WINDOW_TYPE_TOOLBAR");
-	netatom[NetWMWindowTypeToolbar] = getatom(xc, "_NET_WM_WINDOW_TYPE_UTILITY");
+	netatom[NetWMWindowTypeToolbar] = getatom(xc, "_NET_WM_WINDOW_TYPE_TOOLBAR");
+	netatom[NetWMWindowTypeUtility] = getatom(xc, "_NET_WM_WINDOW_TYPE_UTILITY");
 
 	/* assign the one and only seat */
 	wlr_xwayland_set_seat(xwayland, seat);


### PR DESCRIPTION
The initialization of the utility window type and the toolbar window type were swapped.

Additionally, variables xcursor and xcursor_mgr are only used
when xwayland is defined, so I make the variables declaration
contingent on whether xwayland is being used