### PR TITLE
Setting monitor modes in config

### DIFF
--- a/config.def.h
+++ b/config.def.h
@@ -28,9 +28,9 @@ static const Layout layouts[] = {
  * The order in which monitors are defined determines their position.
  * Non-configured monitors are always added to the left. */
 static const MonitorRule monrules[] = {
-	/* name       mfact nmaster scale layout       rotate/reflect x y */
+	/* name       mfact nmaster scale layout       rotate/reflect              x  y  w     h     rate */
 	/* example of a HiDPI laptop monitor:
-	{ "eDP-1",    0.5,  1,      2,    &layouts[0], WL_OUTPUT_TRANSFORM_NORMAL, 0, 0 },
+	{ "eDP-1",    0.5,  1,      2,    &layouts[0], WL_OUTPUT_TRANSFORM_NORMAL, 0, 0, 1920, 1080, 60000 },
 	*/
 	/* the order in which monitors are defined here affects the order in which
 	 * focusmon and tagmon cycle trough the monitors */


### PR DESCRIPTION
### Description

Allow setting custom modes in the config file.

If set to 0, 0, 0, will use monitor's preferred mode.
```
{ "eDP-1",    0.5,  1,      2,    &layouts[0], WL_OUTPUT_TRANSFORM_NORMAL, 0, 0, 0, 0, 0 },
```

Otherwise, if all three values are non-zero, 
1. If monitor has no modes, set using custom mode function.
1. Loop through monitor modes
    1. If exact match, use that mode.
    1. If no exact matches, but resolution matches, use last mode in matching list (I suspect the highest refresh rate).
1. Fallback to custom mode.

I suspect the logic could be shortened a little, since if step 1 is skipped, there should be an empty loop, and the fallback will trigger. But my C is rusty.

### Motivation

I have monitors with preferred modes 1920x1080@144 and 3840x2160@30, and I personally prefer 1920x1080@240 and 1920x1080@60 respectively.

### Disclaimer

I have almost no wayland knowledge, and I have not touched C in a long time.

