### PR TITLE
Add a nix-shell file to create a build environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,12 @@ dwl has only two dependencies: wlroots-git and wayland-protocols. Simply install
 
 To enable XWayland, you should also install xorg-xwayland and uncomment its flag in `config.mk`.
 
+### Nix
+
+If `config.mk` has the xwayland flag, set `enableXWayland` to `true` in `default.nix`.
+
+Run `nix-shell --pure` to enter the shell, and then `make` to build dwl.
+
 ## Configuration
 
 All configuration is done by editing `config.h` and recompiling, in the same manner as dwm. There is no way to separately restart the window manager in Wayland without restarting the entire display server, so any changes will take effect the next time dwl is executed.

--- a/default.nix
+++ b/default.nix
@@ -1,8 +1,8 @@
 { pkgs ? import <nixpkgs> { } }:
 let
   enableXWayland = false;
-  version = "4f80fab337f10b4ad2043b834606540895b8df36";
-  sha256 = "0zsfglyfmzsxf6vkdv999z49v66pwcyffb0pn824ciafwna2408r";
+  version = "dc61f471da1a1c9264167635c286b6dcb37b3d6f";
+  sha256 = "0k31chpc4facn7n7kmk0s5wp7vj7mpapwk4as6pjhi1rq37g34lf";
 
   wlroots-git = pkgs.wlroots.overrideAttrs (old: {
     version = version;

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,31 @@
+{ pkgs ? import <nixpkgs> { } }:
+let
+  enableXWayland = false;
+  version = "4f80fab337f10b4ad2043b834606540895b8df36";
+  sha256 = "0zsfglyfmzsxf6vkdv999z49v66pwcyffb0pn824ciafwna2408r";
+
+  wlroots-git = pkgs.wlroots.overrideAttrs (old: {
+    version = version;
+    src = pkgs.fetchFromGitHub {
+      owner = "swaywm";
+      repo = "wlroots";
+      rev = version;
+      sha256 = sha256;
+    };
+    buildInputs = old.buildInputs ++ [ pkgs.libuuid ];
+  });
+in pkgs.mkShell {
+  name = "dwl-env";
+  nativeBuildInputs = with pkgs; [ cmake pkg-config ];
+  buildInputs = with pkgs;
+    [
+      libGL
+      libinput
+      libxkbcommon
+      pixman
+      wayland
+      wayland-protocols
+      wlroots-git
+      xorg.libxcb
+    ] ++ pkgs.lib.optional enableXWayland [ x11 ];
+}


### PR DESCRIPTION
### Description

This adds a `default.nix` file that is read by the program nix-shell. It creates a shell environment with the required dependencies to build dwl. I also added a little instruction to the README.md file.

### Motivation

I had to fork nixpkgs to install a more recent version of wlroots so that I could build dwl. Since configuring dwl requires building, having nix-shell set up the build environment with library dependencies saves me a lot of time.