### PR TITLE
Add config.h to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dwl
 *-protocol.c
 *-protocol.h
 .ccls-cache
+config.h


### PR DESCRIPTION
### Motivation

`config.h` is effectively build state, this stops anyone accidentally committing it.