### PR TITLE
Interface to display tag information on status bar

### DIFF
--- a/dwl.c
+++ b/dwl.c
@@ -2200,6 +2200,7 @@ tag(const Arg *arg)
 		focusclient(focustop(selmon), 1);
 		arrange(selmon);
 	}
+    statusbar();
 }
 
 void
@@ -2269,6 +2270,7 @@ toggletag(const Arg *arg)
 		focusclient(focustop(selmon), 1);
 		arrange(selmon);
 	}
+    statusbar();
 }
 
 void
@@ -2281,6 +2283,7 @@ toggleview(const Arg *arg)
 		focusclient(focustop(selmon), 1);
 		arrange(selmon);
 	}
+    statusbar();
 }
 
 void
@@ -2361,6 +2364,7 @@ view(const Arg *arg)
 		selmon->tagset[selmon->seltags] = arg->ui & TAGMASK;
 	focusclient(focustop(selmon), 1);
 	arrange(selmon);
+    statusbar();
 }
 
 void

--- a/dwl.c
+++ b/dwl.c
@@ -280,6 +280,7 @@ static void setmon(Client *c, Monitor *m, unsigned int newtags);
 static void setup(void);
 static void sigchld(int unused);
 static void spawn(const Arg *arg);
+static void statusbar(void);
 static void tag(const Arg *arg);
 static void tagmon(const Arg *arg);
 static void tile(Monitor *m);
@@ -1116,6 +1117,7 @@ focusclient(Client *c, int lift)
 		wl_list_insert(&fstack, &c->flink);
 		selmon = c->mon;
 	}
+    statusbar();
 
 	/* Deactivate old client if focus is changing */
 	if (old && (!c || client_surface(c) != old)) {
@@ -1914,6 +1916,7 @@ setlayout(const Arg *arg)
 		selmon->lt[selmon->sellt] = (Layout *)arg->v;
 	/* TODO change layout symbol? */
 	arrange(selmon);
+    statusbar();
 }
 
 /* arg > 1.0 will set mfact absolutely */
@@ -2153,6 +2156,39 @@ spawn(const Arg *arg)
 		execvp(((char **)arg->v)[0], (char **)arg->v);
 		EBARF("dwl: execvp %s failed", ((char **)arg->v)[0]);
 	}
+}
+
+void
+statusbar(void)
+{
+	Monitor *m = NULL;
+	Client *c = NULL;
+	FILE *taginfo;
+	const char *title;
+	char fname[30]="";
+	unsigned int activetags;
+
+	//Add WAYLAND_DISPLAY to filename so each session has a predictable file
+	snprintf(fname, 30, "/tmp/dwltags-%s", getenv("WAYLAND_DISPLAY"));
+
+	if (!(taginfo = fopen(fname, "w")))
+		return;
+
+	wl_list_for_each(m, &mons, link) {
+		activetags=0;
+		wl_list_for_each(c, &clients, link) {
+			if (c->mon == m)
+				activetags |= c->tags;
+		}
+		if (focustop(m))
+			fprintf(taginfo, "%s\n", client_get_title(focustop(m)));
+		else
+			fprintf(taginfo, "\n");
+
+		fprintf(taginfo, "%u %u %u %s\n", m == selmon,
+				activetags, m->tagset[m->seltags], selmon->lt[selmon->sellt]->symbol);
+	}
+	fclose (taginfo);
 }
 
 void

--- a/dwl.c
+++ b/dwl.c
@@ -1846,6 +1846,7 @@ run(char *startup_cmd)
 		if (startup_pid < 0)
 			EBARF("startup: fork");
 		if (startup_pid == 0) {
+			dup2(STDERR_FILENO, STDOUT_FILENO);
 			execl("/bin/sh", "/bin/sh", "-c", startup_cmd, NULL);
 			EBARF("startup: execl");
 		}
@@ -2152,6 +2153,7 @@ void
 spawn(const Arg *arg)
 {
 	if (fork() == 0) {
+		dup2(STDERR_FILENO, STDOUT_FILENO);
 		setsid();
 		execvp(((char **)arg->v)[0], (char **)arg->v);
 		EBARF("dwl: execvp %s failed", ((char **)arg->v)[0]);

--- a/dwl.c
+++ b/dwl.c
@@ -2163,15 +2163,7 @@ statusbar(void)
 {
 	Monitor *m = NULL;
 	Client *c = NULL;
-	FILE *taginfo;
-	char fname[30]="";
 	unsigned int activetags;
-
-	//Add WAYLAND_DISPLAY to filename so each session has a predictable file
-	snprintf(fname, 30, "/tmp/dwltags-%s", getenv("WAYLAND_DISPLAY"));
-
-	if (!(taginfo = fopen(fname, "w")))
-		return;
 
 	wl_list_for_each(m, &mons, link) {
 		activetags=0;
@@ -2180,15 +2172,15 @@ statusbar(void)
 				activetags |= c->tags;
 		}
 		if (focustop(m))
-			fprintf(taginfo, "%s title %s\n", m->wlr_output->name, client_get_title(focustop(m)));
+			fprintf(stdout, "%s title %s\n", m->wlr_output->name, client_get_title(focustop(m)));
 		else
-			fprintf(taginfo, "%s title \n", m->wlr_output->name);
+			fprintf(stdout, "%s title \n", m->wlr_output->name);
 
-		fprintf(taginfo, "%s selmon %u\n", m->wlr_output->name, m == selmon);
-		fprintf(taginfo, "%s tags %u %u\n", m->wlr_output->name, activetags, m->tagset[m->seltags]);
-		fprintf(taginfo, "%s layout %s\n", m->wlr_output->name, m->lt[m->sellt]->symbol);
+		fprintf(stdout, "%s selmon %u\n", m->wlr_output->name, m == selmon);
+		fprintf(stdout, "%s tags %u %u\n", m->wlr_output->name, activetags, m->tagset[m->seltags]);
+		fprintf(stdout, "%s layout %s\n", m->wlr_output->name, m->lt[m->sellt]->symbol);
 	}
-	fclose (taginfo);
+	fflush(stdout);
 }
 
 void

--- a/dwl.c
+++ b/dwl.c
@@ -2164,7 +2164,6 @@ statusbar(void)
 	Monitor *m = NULL;
 	Client *c = NULL;
 	FILE *taginfo;
-	const char *title;
 	char fname[30]="";
 	unsigned int activetags;
 

--- a/dwl.c
+++ b/dwl.c
@@ -260,6 +260,7 @@ static void outputmgrapplyortest(struct wlr_output_configuration_v1 *config, int
 static void outputmgrtest(struct wl_listener *listener, void *data);
 static void pointerfocus(Client *c, struct wlr_surface *surface,
 		double sx, double sy, uint32_t time);
+static void printstatus(void);
 static void quit(const Arg *arg);
 static void render(struct wlr_surface *surface, int sx, int sy, void *data);
 static void renderclients(Monitor *m, struct timespec *now);
@@ -280,7 +281,6 @@ static void setmon(Client *c, Monitor *m, unsigned int newtags);
 static void setup(void);
 static void sigchld(int unused);
 static void spawn(const Arg *arg);
-static void statusbar(void);
 static void tag(const Arg *arg);
 static void tagmon(const Arg *arg);
 static void tile(Monitor *m);
@@ -1117,7 +1117,7 @@ focusclient(Client *c, int lift)
 		wl_list_insert(&fstack, &c->flink);
 		selmon = c->mon;
 	}
-	statusbar();
+	printstatus();
 
 	/* Deactivate old client if focus is changing */
 	if (old && (!c || client_surface(c) != old)) {
@@ -1605,6 +1605,31 @@ pointerfocus(Client *c, struct wlr_surface *surface, double sx, double sy,
 }
 
 void
+printstatus(void)
+{
+	Monitor *m = NULL;
+	Client *c = NULL;
+	unsigned int activetags;
+
+	wl_list_for_each(m, &mons, link) {
+		activetags=0;
+		wl_list_for_each(c, &clients, link) {
+			if (c->mon == m)
+				activetags |= c->tags;
+		}
+		if (focustop(m))
+			printf("%s title %s\n", m->wlr_output->name, client_get_title(focustop(m)));
+		else
+			printf("%s title \n", m->wlr_output->name);
+
+		printf("%s selmon %u\n", m->wlr_output->name, m == selmon);
+		printf("%s tags %u %u\n", m->wlr_output->name, activetags, m->tagset[m->seltags]);
+		printf("%s layout %s\n", m->wlr_output->name, m->lt[m->sellt]->symbol);
+	}
+	fflush(stdout);
+}
+
+void
 quit(const Arg *arg)
 {
 	wl_display_terminate(dpy);
@@ -1917,7 +1942,7 @@ setlayout(const Arg *arg)
 		selmon->lt[selmon->sellt] = (Layout *)arg->v;
 	/* TODO change layout symbol? */
 	arrange(selmon);
-	statusbar();
+	printstatus();
 }
 
 /* arg > 1.0 will set mfact absolutely */
@@ -2161,31 +2186,6 @@ spawn(const Arg *arg)
 }
 
 void
-statusbar(void)
-{
-	Monitor *m = NULL;
-	Client *c = NULL;
-	unsigned int activetags;
-
-	wl_list_for_each(m, &mons, link) {
-		activetags=0;
-		wl_list_for_each(c, &clients, link) {
-			if (c->mon == m)
-				activetags |= c->tags;
-		}
-		if (focustop(m))
-			fprintf(stdout, "%s title %s\n", m->wlr_output->name, client_get_title(focustop(m)));
-		else
-			fprintf(stdout, "%s title \n", m->wlr_output->name);
-
-		fprintf(stdout, "%s selmon %u\n", m->wlr_output->name, m == selmon);
-		fprintf(stdout, "%s tags %u %u\n", m->wlr_output->name, activetags, m->tagset[m->seltags]);
-		fprintf(stdout, "%s layout %s\n", m->wlr_output->name, m->lt[m->sellt]->symbol);
-	}
-	fflush(stdout);
-}
-
-void
 tag(const Arg *arg)
 {
 	Client *sel = selclient();
@@ -2194,7 +2194,7 @@ tag(const Arg *arg)
 		focusclient(focustop(selmon), 1);
 		arrange(selmon);
 	}
-	statusbar();
+	printstatus();
 }
 
 void
@@ -2264,7 +2264,7 @@ toggletag(const Arg *arg)
 		focusclient(focustop(selmon), 1);
 		arrange(selmon);
 	}
-	statusbar();
+	printstatus();
 }
 
 void
@@ -2277,7 +2277,7 @@ toggleview(const Arg *arg)
 		focusclient(focustop(selmon), 1);
 		arrange(selmon);
 	}
-	statusbar();
+	printstatus();
 }
 
 void
@@ -2358,7 +2358,7 @@ view(const Arg *arg)
 		selmon->tagset[selmon->seltags] = arg->ui & TAGMASK;
 	focusclient(focustop(selmon), 1);
 	arrange(selmon);
-	statusbar();
+	printstatus();
 }
 
 void

--- a/dwl.c
+++ b/dwl.c
@@ -2180,12 +2180,13 @@ statusbar(void)
 				activetags |= c->tags;
 		}
 		if (focustop(m))
-			fprintf(taginfo, "%s\n", client_get_title(focustop(m)));
+			fprintf(taginfo, "%s title %s\n", m->wlr_output->name, client_get_title(focustop(m)));
 		else
-			fprintf(taginfo, "\n");
+			fprintf(taginfo, "%s title \n", m->wlr_output->name);
 
-		fprintf(taginfo, "%u %u %u %s\n", m == selmon,
-				activetags, m->tagset[m->seltags], selmon->lt[selmon->sellt]->symbol);
+		fprintf(taginfo, "%s selmon %u\n", m->wlr_output->name, m == selmon);
+		fprintf(taginfo, "%s tags %u %u\n", m->wlr_output->name, activetags, m->tagset[m->seltags]);
+		fprintf(taginfo, "%s layout %s\n", m->wlr_output->name, m->lt[m->sellt]->symbol);
 	}
 	fclose (taginfo);
 }

--- a/dwl.c
+++ b/dwl.c
@@ -1117,7 +1117,7 @@ focusclient(Client *c, int lift)
 		wl_list_insert(&fstack, &c->flink);
 		selmon = c->mon;
 	}
-    statusbar();
+	statusbar();
 
 	/* Deactivate old client if focus is changing */
 	if (old && (!c || client_surface(c) != old)) {
@@ -1916,7 +1916,7 @@ setlayout(const Arg *arg)
 		selmon->lt[selmon->sellt] = (Layout *)arg->v;
 	/* TODO change layout symbol? */
 	arrange(selmon);
-    statusbar();
+	statusbar();
 }
 
 /* arg > 1.0 will set mfact absolutely */
@@ -2192,7 +2192,7 @@ tag(const Arg *arg)
 		focusclient(focustop(selmon), 1);
 		arrange(selmon);
 	}
-    statusbar();
+	statusbar();
 }
 
 void
@@ -2262,7 +2262,7 @@ toggletag(const Arg *arg)
 		focusclient(focustop(selmon), 1);
 		arrange(selmon);
 	}
-    statusbar();
+	statusbar();
 }
 
 void
@@ -2275,7 +2275,7 @@ toggleview(const Arg *arg)
 		focusclient(focustop(selmon), 1);
 		arrange(selmon);
 	}
-    statusbar();
+	statusbar();
 }
 
 void
@@ -2356,7 +2356,7 @@ view(const Arg *arg)
 		selmon->tagset[selmon->seltags] = arg->ui & TAGMASK;
 	focusclient(focustop(selmon), 1);
 	arrange(selmon);
-    statusbar();
+	statusbar();
 }
 
 void


### PR DESCRIPTION
I would like to add in a way to replicate the tag, layout, and client title information that DWM provides in its bar. I've implemented a solution using a file in /tmp as a proof of concept; I would love feedback on how to handle the interface. The file this creates can be parsed by a simple script and added as a waybar module.