### PR TITLE
pipe status info into -s command

### DIFF
--- a/dwl.c
+++ b/dwl.c
@@ -1805,15 +1805,22 @@ run(char *startup_cmd)
 	setenv("WAYLAND_DISPLAY", socket, 1);
 
 	if (startup_cmd) {
+		int piperw[2];
+		pipe(piperw);
 		startup_pid = fork();
 		if (startup_pid < 0)
 			EBARF("startup: fork");
 		if (startup_pid == 0) {
-			dup2(STDERR_FILENO, STDOUT_FILENO);
+			dup2(piperw[0], STDIN_FILENO);
+			close(piperw[1]);
 			execl("/bin/sh", "/bin/sh", "-c", startup_cmd, NULL);
 			EBARF("startup: execl");
 		}
+		dup2(piperw[1], STDOUT_FILENO);
+		close(piperw[0]);
 	}
+	/* If nobody is reading the status output, don't terminate */
+	signal(SIGPIPE, SIG_IGN);
 
 	/* Run the Wayland event loop. This does not return until you exit the
 	 * compositor. Starting the backend rigged up all of the necessary event


### PR DESCRIPTION
Unlike with X window managers, the display socket in Wayland isn't set up prior to starting the compositor.  Because of this, you can't pipe the compositor's output directly into a program which needs access to `$WAYLAND_DISPLAY`, which is a typical setup for this purpose.  Existing scripts have been forced to create a pipe/FIFO or a temporary file as an intermediary.

Instead, send the status info directly to stdin of the -s command, which *does* have access to `$WAYLAND_DISPLAY`.

Fixes #103.