### PR TITLE
Add uninstall target in makefile like dwm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,10 @@ clean:
 install: dwl
 	install -D dwl $(PREFIX)/bin/dwl
 
-.PHONY: all clean install
+uninstall:
+	rm -f $(PREFIX)/bin/dwl
+
+.PHONY: all clean install uninstall
 
 # wayland-scanner is a tool which generates C headers and rigging for Wayland
 # protocols, which are specified in XML. wlroots requires you to rig these up


### PR DESCRIPTION
This is just a really simple commit that allows users to run the "make uninstall" command to remove dwl, like it is possible for dwm.