### PR TITLE
Wait until map to set window's tiled state

### DIFF
--- a/dwl.c
+++ b/dwl.c
@@ -885,10 +885,6 @@ createnotify(struct wl_listener *listener, void *data)
 	c->surface.xdg = xdg_surface;
 	c->bw = borderpx;
 
-	/* Tell the client not to try anything fancy */
-	wlr_xdg_toplevel_set_tiled(c->surface.xdg, WLR_EDGE_TOP |
-			WLR_EDGE_BOTTOM | WLR_EDGE_LEFT | WLR_EDGE_RIGHT);
-
 	LISTEN(&xdg_surface->surface->events.commit, &c->commit, commitnotify);
 	LISTEN(&xdg_surface->events.map, &c->map, mapnotify);
 	LISTEN(&xdg_surface->events.unmap, &c->unmap, unmapnotify);
@@ -1307,6 +1303,10 @@ mapnotify(struct wl_listener *listener, void *data)
 	client_get_geometry(c, &c->geom);
 	c->geom.width += 2 * c->bw;
 	c->geom.height += 2 * c->bw;
+
+	/* Tell the client not to try anything fancy */
+	wlr_xdg_toplevel_set_tiled(c->surface.xdg, WLR_EDGE_TOP |
+			WLR_EDGE_BOTTOM | WLR_EDGE_LEFT | WLR_EDGE_RIGHT);
 
 	/* Set initial monitor, tags, floating status, and focus */
 	applyrules(c);


### PR DESCRIPTION
Workaround for a bug in Chromium where it fails to attach a buffer to the surface.  Fixes #119.