### PR TITLE
fix crash when a client opens in full screen mode

### DIFF
--- a/dwl.c
+++ b/dwl.c
@@ -1934,6 +1934,9 @@ setmon(Client *c, Monitor *m, unsigned int newtags)
 {
 	Monitor *oldmon = c->mon;
 
+	if (m)
+		c->tags = newtags ? newtags : m->tagset[m->seltags]; /* assign tags of target monitor */
+
 	if (oldmon == m)
 		return;
 	c->mon = m;
@@ -1947,7 +1950,6 @@ setmon(Client *c, Monitor *m, unsigned int newtags)
 		/* Make sure window actually overlaps with the monitor */
 		applybounds(c, &m->m);
 		wlr_surface_send_enter(client_surface(c), m->wlr_output);
-		c->tags = newtags ? newtags : m->tagset[m->seltags]; /* assign tags of target monitor */
 		arrange(m);
 	}
 	focusclient(focustop(selmon), 1);

--- a/dwl.c
+++ b/dwl.c
@@ -1018,6 +1018,9 @@ togglefullscreen(const Arg *arg)
 void
 setfullscreen(Client *c, int fullscreen)
 {
+	if (!c->mon)
+		return;
+
 	c->isfullscreen = fullscreen;
 	c->bw = (1 - fullscreen) * borderpx;
 	client_set_fullscreen(c, fullscreen);

--- a/dwl.c
+++ b/dwl.c
@@ -888,6 +888,9 @@ createnotify(struct wl_listener *listener, void *data)
 	c->surface.xdg = xdg_surface;
 	c->bw = borderpx;
 
+	/* set monitor, then it will be overwritten by applyrules */
+	setmon(c,selmon, 0);
+
 	LISTEN(&xdg_surface->surface->events.commit, &c->commit, commitnotify);
 	LISTEN(&xdg_surface->events.map, &c->map, mapnotify);
 	LISTEN(&xdg_surface->events.unmap, &c->unmap, unmapnotify);
@@ -1315,6 +1318,10 @@ mapnotify(struct wl_listener *listener, void *data)
 
 	/* Set initial monitor, tags, floating status, and focus */
 	applyrules(c);
+
+	arrange(c->mon);
+	if (VISIBLEON(c, c->mon))
+		focusclient(c, 1);
 }
 
 void
@@ -2453,6 +2460,9 @@ createnotifyx11(struct wl_listener *listener, void *data)
 	c->type = xwayland_surface->override_redirect ? X11Unmanaged : X11Managed;
 	c->bw = borderpx;
 	c->isfullscreen = 0;
+
+	/* set monitor, then it will be overwritten by applyrules */
+	setmon(c,selmon, 0);
 
 	/* Listen to the various events it can emit */
 	LISTEN(&xwayland_surface->events.map, &c->map, mapnotify);

--- a/dwl.c
+++ b/dwl.c
@@ -1021,9 +1021,6 @@ togglefullscreen(const Arg *arg)
 void
 setfullscreen(Client *c, int fullscreen)
 {
-	if (!c->mon)
-		return;
-
 	c->isfullscreen = fullscreen;
 	c->bw = (1 - fullscreen) * borderpx;
 	client_set_fullscreen(c, fullscreen);


### PR DESCRIPTION
try to open a client in fullscreen mode (example: foot -F) causes that
dwl crash, this prevent crash but this isn't a solution, since client will
be open in normal mode, we must find a way to set c->mon in createnotify
function