### PR TITLE
wlr_layer_surface_v1_close has been replaced by wlr_layer_surface_v1_…

### DIFF
--- a/dwl.c
+++ b/dwl.c
@@ -553,7 +553,7 @@ arrangelayer(Monitor *m, struct wl_list *list, struct wlr_box *usable_area, int 
 			box.y -= state->margin.bottom;
 		}
 		if (box.width < 0 || box.height < 0) {
-			wlr_layer_surface_v1_close(wlr_layer_surface);
+			wlr_layer_surface_v1_destroy(wlr_layer_surface);
 			continue;
 		}
 		layersurface->geo = box;


### PR DESCRIPTION
As seen in this [commit](https://github.com/swaywm/wlroots/commit/0c19a2826632f5f0f9ac615b010d319f4cfa2c77)

Fixes #142 