### PR TITLE
reset cursor mode when grabc is unmapped

### DIFF
--- a/dwl.c
+++ b/dwl.c
@@ -2292,6 +2292,10 @@ unmapnotify(struct wl_listener *listener, void *data)
 {
 	/* Called when the surface is unmapped, and should no longer be shown. */
 	Client *c = wl_container_of(listener, c, unmap);
+	if (c == grabc) {
+		cursor_mode = CurNormal;
+		grabc = NULL;
+	}
 	wl_list_remove(&c->link);
 	if (client_is_unmanaged(c))
 		return;


### PR DESCRIPTION
Prevents segfaults when a client crashes during resize/move.