### PR TITLE
`wlr_xdg_surface.configure_serial` has been moved into `wlr_xdg_surface_state`

### DIFF
--- a/dwl.c
+++ b/dwl.c
@@ -779,7 +779,7 @@ commitnotify(struct wl_listener *listener, void *data)
 	Client *c = wl_container_of(listener, c, commit);
 
 	/* mark a pending resize as completed */
-	if (c->resize && c->resize <= c->surface.xdg->configure_serial)
+	if (c->resize && c->resize <= c->surface.xdg->current.configure_serial)
 		c->resize = 0;
 }
 


### PR DESCRIPTION
as seen in swaywm/wlroots@0e34208