### PR TITLE
-s: close unused fds

### DIFF
--- a/dwl.c
+++ b/dwl.c
@@ -1823,11 +1823,13 @@ run(char *startup_cmd)
 			EBARF("startup: fork");
 		if (startup_pid == 0) {
 			dup2(piperw[0], STDIN_FILENO);
+			close(piperw[0]);
 			close(piperw[1]);
 			execl("/bin/sh", "/bin/sh", "-c", startup_cmd, NULL);
 			EBARF("startup: execl");
 		}
 		dup2(piperw[1], STDOUT_FILENO);
+		close(piperw[1]);
 		close(piperw[0]);
 	}
 	/* If nobody is reading the status output, don't terminate */


### PR DESCRIPTION
dup2 doesn’t close fds, it only duplicates them.  The old ones weren’t
closed, causing problems (like dwl blocking due to the child process
never reading from the reading end, even if stdin has been closed).

I had the same problem as before—dwl blocking—and thought to myself:
Are the pipes closed properly? As it turns out, they aren’t. I believe
that’s the current problem.
