### PR TITLE
fix client_set_tiled which is currently ignoring its "edges" argument

### DIFF
--- a/client.h
+++ b/client.h
@@ -156,8 +156,7 @@ client_set_tiled(Client *c, uint32_t edges)
 	if (client_is_x11(c))
 		return;
 #endif
-	wlr_xdg_toplevel_set_tiled(c->surface.xdg, WLR_EDGE_TOP |
-			WLR_EDGE_BOTTOM | WLR_EDGE_LEFT | WLR_EDGE_RIGHT);
+	wlr_xdg_toplevel_set_tiled(c->surface.xdg, edges);
 }
 
 static inline struct wlr_surface *


### PR DESCRIPTION
`client_set_tiled` seems to currently ignore its `edges` argument. This currently happens to work because `client_set_tiled` is only called once with the same value as the one used in its body.