### PR TITLE
Newly launched or closed clients ALWAYS generate status update

### DIFF
--- a/dwl.c
+++ b/dwl.c
@@ -1320,6 +1320,7 @@ mapnotify(struct wl_listener *listener, void *data)
 
 	/* Set initial monitor, tags, floating status, and focus */
 	applyrules(c);
+	printstatus();
 }
 
 void
@@ -2290,6 +2291,7 @@ unmapnotify(struct wl_listener *listener, void *data)
 	setmon(c, NULL, 0);
 	wl_list_remove(&c->flink);
 	wl_list_remove(&c->slink);
+	printstatus();
 }
 
 void


### PR DESCRIPTION
Prior to this change, if a client whose tag(s) are not currently
selected is launched or killed, no update to status was printed and
status bars being fed by printstatus() did not update newly active
or newly inactive (but unselected) tags.

(This is identical to #178 ; I made a proper branch in my own repo and was forced to remake this PR.)
Resolves #179 