### PR TITLE
die on allocation failure

### DIFF
--- a/dwl.c
+++ b/dwl.c
@@ -787,6 +787,8 @@ createkeyboard(struct wlr_input_device *device)
 	struct xkb_context *context;
 	struct xkb_keymap *keymap;
 	Keyboard *kb = device->data = calloc(1, sizeof(*kb));
+	if (!kb)
+		EBARF("createkeyboard: calloc");
 	kb->device = device;
 
 	/* Prepare an XKB keymap and assign it to the keyboard. */
@@ -818,6 +820,8 @@ createmon(struct wl_listener *listener, void *data)
 	struct wlr_output *wlr_output = data;
 	const MonitorRule *r;
 	Monitor *m = wlr_output->data = calloc(1, sizeof(*m));
+	if (!m)
+		EBARF("createmon: calloc");
 	m->wlr_output = wlr_output;
 
 	wlr_output_init_render(wlr_output, alloc, drw);
@@ -891,6 +895,8 @@ createnotify(struct wl_listener *listener, void *data)
 
 	/* Allocate a Client for this surface */
 	c = xdg_surface->data = calloc(1, sizeof(*c));
+	if (!c)
+		EBARF("createnotify: calloc");
 	c->surface.xdg = xdg_surface;
 	c->bw = borderpx;
 
@@ -917,6 +923,8 @@ createlayersurface(struct wl_listener *listener, void *data)
 	}
 
 	layersurface = calloc(1, sizeof(LayerSurface));
+	if (!layersurface)
+		EBARF("layersurface: calloc");
 	LISTEN(&wlr_layer_surface->surface->events.commit,
 		&layersurface->surface_commit, commitlayersurfacenotify);
 	LISTEN(&wlr_layer_surface->events.destroy, &layersurface->destroy,
@@ -2478,6 +2486,8 @@ createnotifyx11(struct wl_listener *listener, void *data)
 
 	/* Allocate a Client for this surface */
 	c = xwayland_surface->data = calloc(1, sizeof(*c));
+	if (!c)
+		EBARF("createnotifyx11: calloc");
 	c->surface.xwayland = xwayland_surface;
 	c->type = xwayland_surface->override_redirect ? X11Unmanaged : X11Managed;
 	c->bw = borderpx;


### PR DESCRIPTION
While ideally we should try to recover from allocation failure, this is better than ignoring it.