### PR TITLE
fix crash when borders align perfectly with screen borders

### DIFF
--- a/dwl.c
+++ b/dwl.c
@@ -1878,8 +1878,8 @@ run(char *startup_cmd)
 void
 scalebox(struct wlr_box *box, float scale)
 {
-	box->width =  ROUND((box->x + box->width) * scale) -  ROUND(box->x * scale);
-	box->height = ROUND((box->y + box->height) * scale) - ROUND(box->y * scale);
+	box->width =  MAX(1, ROUND((box->x + box->width) * scale) -  ROUND(box->x * scale));
+	box->height = MAX(1, ROUND((box->y + box->height) * scale) - ROUND(box->y * scale));
 	box->x = ROUND(box->x * scale);
 	box->y = ROUND(box->y * scale);
 }


### PR DESCRIPTION
See https://github.com/djpohly/dwl/pull/148#issuecomment-1066279005

Steps to reproduce:

- create a floating window
- move it to the top or left corner of the screen so that the border aligns perfectly with the screen border (wiggle around for a bit for good measure)
- dwl crashes