### PR TITLE
fix drag doesn't work correctly (reported on Discord)

### DIFF
--- a/dwl.c
+++ b/dwl.c
@@ -1415,21 +1415,20 @@ motionnotify(uint32_t time)
 	double sx = 0, sy = 0;
 	Client *c = NULL;
 	struct wlr_surface *surface = NULL;
+	struct wlr_drag_icon *icon;
 
 	/* time is 0 in internal calls meant to restore pointer focus. */
 	if (time) {
-		struct wlr_drag_icon *icon;
 		wlr_idle_notify_activity(idle, seat);
 
 		/* Update selmon (even while dragging a window) */
 		if (sloppyfocus)
 			selmon = xytomon(cursor->x, cursor->y);
-
-		if (seat->drag && (icon = seat->drag->icon))
-			wlr_scene_node_set_position(icon->data, cursor->x + icon->surface->sx,
-					cursor->y + icon->surface->sy);
 	}
 
+	if (seat->drag && (icon = seat->drag->icon))
+		wlr_scene_node_set_position(icon->data, cursor->x + icon->surface->sx,
+				cursor->y + icon->surface->sy);
 	/* If we are currently grabbing the mouse, handle and return */
 	if (cursor_mode == CurMove) {
 		/* Move the grabbed client to the new position. */
@@ -2081,7 +2080,7 @@ startdrag(struct wl_listener *listener, void *data)
 		return;
 
 	drag->icon->data = wlr_scene_subsurface_tree_create(layers[LyrTop], drag->icon->surface);
-	wlr_scene_node_raise_to_top(drag->icon->data);
+	motionnotify(0);
 	wl_signal_add(&drag->icon->events.destroy, &drag_icon_destroy);
 }
 

--- a/dwl.c
+++ b/dwl.c
@@ -1418,11 +1418,16 @@ motionnotify(uint32_t time)
 
 	/* time is 0 in internal calls meant to restore pointer focus. */
 	if (time) {
+		struct wlr_drag_icon *icon;
 		wlr_idle_notify_activity(idle, seat);
 
 		/* Update selmon (even while dragging a window) */
 		if (sloppyfocus)
 			selmon = xytomon(cursor->x, cursor->y);
+
+		if (seat->drag && (icon = seat->drag->icon))
+			wlr_scene_node_set_position(icon->data, cursor->x + icon->surface->sx,
+					cursor->y + icon->surface->sy);
 	}
 
 	/* If we are currently grabbing the mouse, handle and return */
@@ -1561,7 +1566,6 @@ pointerfocus(Client *c, struct wlr_surface *surface, double sx, double sy,
 {
 	struct timespec now;
 	int internal_call = !time;
-	struct wlr_drag_icon *icon;
 
 	if (sloppyfocus && !internal_call && c && !client_is_unmanaged(c))
 		focusclient(c, 0);
@@ -1583,13 +1587,6 @@ pointerfocus(Client *c, struct wlr_surface *surface, double sx, double sy,
 	wlr_seat_pointer_notify_enter(seat, surface, sx, sy);
 	wlr_seat_pointer_notify_motion(seat, time, sx, sy);
 
-	/* If there are is a drag icon, update its position */
-	/* For anyone who wants to change this function: for some reason
-	 * (maybe a wlroots bug?, or is it intended?) if we change the node position
-	 * before telling the seat for a motion, the clients don't recognize the drag */
-	if (seat->drag && (icon = seat->drag->icon))
-		wlr_scene_node_set_position(icon->data, cursor->x + icon->surface->sx,
-				cursor->y + icon->surface->sy);
 }
 
 void


### PR DESCRIPTION
Currently `xytonode()` returns the top-most surface under `x` and `y`, this includes drag icon's surface which should not receive focus and this causes when dragging, the client under the cursor doesn't recognize that a drag is happening on its surface

any suggestion or any better solution?