### PR TITLE
Fix flickering on map/unmap

### DIFF
--- a/dwl.c
+++ b/dwl.c
@@ -1689,9 +1689,7 @@ rendermon(struct wl_listener *listener, void *data)
 			skip = 1;
 		}
 	}
-	if (skip)
-		return;
-	if (!skip && !wlr_scene_output_commit(m->scene_output))
+	if (skip || !wlr_scene_output_commit(m->scene_output))
 		return;
 	/* Let clients know a frame has been rendered */
 	wlr_scene_output_send_frame_done(m->scene_output, &now);

--- a/dwl.c
+++ b/dwl.c
@@ -1689,6 +1689,8 @@ rendermon(struct wl_listener *listener, void *data)
 			skip = 1;
 		}
 	}
+	if (skip)
+		return;
 	if (!skip && !wlr_scene_output_commit(m->scene_output))
 		return;
 	/* Let clients know a frame has been rendered */


### PR DESCRIPTION
Yeah so basically we still have the flickering on map/unmap and this will fix it. I'm actually not even sure what the point of skip is since when it's true it doesn't skip(??)