### PR TITLE
Add basic support for pointer constraints

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,9 +56,19 @@ idle-protocol.c:
 
 idle-protocol.o: idle-protocol.h
 
+pointer-constraints-unstable-v1-protocol.h:
+	$(WAYLAND_SCANNER) server-header \
+		$(WAYLAND_PROTOCOLS)/unstable/pointer-constraints/pointer-constraints-unstable-v1.xml $@
+
+pointer-constraints-unstable-v1-protocol.c:
+	$(WAYLAND_SCANNER) private-code \
+		$(WAYLAND_PROTOCOLS)/unstable/pointer-constraints/pointer-constraints-unstable-v1.xml $@
+
+pointer-constraints-unstable-v1-protocol.o: pointer-constraints-unstable-v1-protocol.h
+
 config.h: | config.def.h
 	cp config.def.h $@
 
-dwl.o: config.mk config.h client.h xdg-shell-protocol.h wlr-layer-shell-unstable-v1-protocol.h idle-protocol.h
+dwl.o: config.mk config.h client.h xdg-shell-protocol.h wlr-layer-shell-unstable-v1-protocol.h idle-protocol.h pointer-constraints-unstable-v1-protocol.h
 
-dwl: xdg-shell-protocol.o wlr-layer-shell-unstable-v1-protocol.o idle-protocol.o
+dwl: xdg-shell-protocol.o wlr-layer-shell-unstable-v1-protocol.o idle-protocol.o pointer-constraints-unstable-v1-protocol.o


### PR DESCRIPTION
Without this, mouse movement in FPS games is chaotic. See https://github.com/puppylinux-woof-CE/woof-CE/issues/2534 and https://github.com/puppylinux-woof-CE/woof-CE/issues/2593. 

This is a simplified version of johanmalm/labwc#85.

Reproduced and tested using Crispy Doom, running both natively (with free look enabled) and under Xwayland. Also tested QEMU mouse grab and ungrab under Xwayland.

I'm not sure if I got everything right, especially the handling of destroy_constraint, and the `if constraint` check on input events.