### PR TITLE
Layer shell: Prevent infinte configure/commit loop

### DIFF
--- a/dwl.c
+++ b/dwl.c
@@ -140,6 +140,7 @@ typedef struct {
 typedef struct {
 	/* Must be first */
 	unsigned int type; /* LayerShell */
+	int mapped;
 	struct wlr_scene_node *scene;
 	struct wl_list link;
 	struct wlr_layer_surface_v1 *layer_surface;
@@ -757,6 +758,12 @@ commitlayersurfacenotify(struct wl_listener *listener, void *data)
 
 	if (!wlr_output || !(m = wlr_output->data))
 		return;
+
+	if (wlr_layer_surface->current.committed == 0
+			&& layersurface->mapped == wlr_layer_surface->mapped)
+		return;
+
+	layersurface->mapped = wlr_layer_surface->mapped;
 
 	if (layers[wlr_layer_surface->current.layer] != layersurface->scene) {
 		wl_list_remove(&layersurface->link);


### PR DESCRIPTION
Carried over from #169, with the original commit amended.

> Check the wlr_layer_surface_v1_state.committed bitmask to see if we need
> to rearrange. This is also what sway does.
> 
> Without this check, every commit request (even if only the attached buffer
> changed) will lead to another configure event, which will lead to another
> commit, etc.
> 
> This loop results in swaybg consuming 100% CPU.