### PR TITLE
drop permissions

### DIFF
--- a/dwl.c
+++ b/dwl.c
@@ -1117,6 +1117,23 @@ dirtomon(enum wlr_direction dir)
 	return selmon;
 }
 
+static void
+drop_permissions(void)
+{
+	if (getuid() != geteuid() || getgid() != getegid()) {
+		/* Set the gid and uid in the correct order. */
+		if (setgid(getgid()) != 0) {
+			die("Unable to drop root group, refusing to start");
+		}
+		if (setuid(getuid()) != 0) {
+			die("Unable to drop root user, refusing to start");
+		}
+	}
+	if (setgid(0) != -1 || setuid(0) != -1) {
+		die("Unable to drop root, refusing to start");
+	}
+}
+
 void
 focusclient(Client *c, int lift)
 {
@@ -1928,6 +1945,8 @@ setup(void)
 	 * don't). */
 	if (!(backend = wlr_backend_autocreate(dpy)))
 		die("couldn't create backend");
+
+	drop_permissions();
 
 	/* Initialize the scene graph used to lay out windows */
 	scene = wlr_scene_create();

--- a/dwl.c
+++ b/dwl.c
@@ -1122,16 +1122,13 @@ drop_permissions(void)
 {
 	if (getuid() != geteuid() || getgid() != getegid()) {
 		/* Set the gid and uid in the correct order. */
-		if (setgid(getgid()) != 0) {
+		if (setgid(getgid()) != 0)
 			die("Unable to drop root group, refusing to start");
-		}
-		if (setuid(getuid()) != 0) {
+		if (setuid(getuid()) != 0)
 			die("Unable to drop root user, refusing to start");
-		}
 	}
-	if (setgid(0) != -1 || setuid(0) != -1) {
+	if (setgid(0) != -1 || setuid(0) != -1)
 		die("Unable to drop root, refusing to start");
-	}
 }
 
 void


### PR DESCRIPTION
Resurrecting #36 with some style changes.

This works for me given `seatd` built with `-Dlibseat-builtin=enabled`, `chown :input $(DESTDIR)$(PREFIX)/bin/dwl`, and
`chmod g+s    $(DESTDIR)$(PREFIX)/bin/dwl`. My user is NOT in the `input` group, but is in the `audio`, `video`, and `tty` groups.
