### PR TITLE
Fix flickering on map/unmap, fix 'overshoot'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,11 +15,11 @@ clean:
 	rm -f dwl *.o *-protocol.h *-protocol.c
 
 install: dwl
-	install -Dm755 dwl $(PREFIX)/bin/dwl
-	install -Dm644 dwl.1 $(MANDIR)/man1/dwl.1
+	install -Dm755 dwl $(DESTDIR)$(PREFIX)/bin/dwl
+	install -Dm644 dwl.1 $(DESTDIR)$(MANDIR)/man1/dwl.1
 
 uninstall:
-	rm -f $(PREFIX)/bin/dwl $(MANDIR)/man1/dwl.1
+	rm -f $(DESTDIR)$(PREFIX)/bin/dwl $(DESTDIR)$(MANDIR)/man1/dwl.1
 
 .PHONY: all clean install uninstall
 

--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,6 @@ idle-protocol.o: idle-protocol.h
 config.h: | config.def.h
 	cp config.def.h $@
 
-dwl.o: config.mk config.h client.h xdg-shell-protocol.h wlr-layer-shell-unstable-v1-protocol.h idle-protocol.h
+dwl.o: config.mk config.h client.h xdg-shell-protocol.h wlr-layer-shell-unstable-v1-protocol.h idle-protocol.h util.h
 
-dwl: xdg-shell-protocol.o wlr-layer-shell-unstable-v1-protocol.o idle-protocol.o
+dwl: xdg-shell-protocol.o wlr-layer-shell-unstable-v1-protocol.o idle-protocol.o util.o

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 include config.mk
 
-CFLAGS += -I. -DWLR_USE_UNSTABLE -std=c99
+CFLAGS += -I. -DWLR_USE_UNSTABLE -std=c99 -pedantic
 
 WAYLAND_PROTOCOLS=$(shell pkg-config --variable=pkgdatadir wayland-protocols)
 WAYLAND_SCANNER=$(shell pkg-config --variable=wayland_scanner wayland-scanner)

--- a/config.def.h
+++ b/config.def.h
@@ -13,8 +13,8 @@ static const Rule rules[] = {
 	/* app_id     title       tags mask     isfloating   monitor */
 	/* examples:
 	{ "Gimp",     NULL,       0,            1,           -1 },
-	{ "firefox",  NULL,       1 << 8,       0,           -1 },
 	*/
+	{ "firefox",  NULL,       1 << 8,       0,           -1 },
 };
 
 /* layout(s) */
@@ -43,6 +43,7 @@ static const struct xkb_rule_names xkb_rules = {
 	/* example:
 	.options = "ctrl:nocaps",
 	*/
+	.options = "",
 };
 
 static const int repeat_rate = 25;

--- a/config.mk
+++ b/config.mk
@@ -3,7 +3,7 @@ PREFIX = /usr/local
 MANDIR = $(PREFIX)/share/man
 
 # Default compile flags (overridable by environment)
-CFLAGS ?= -g -Wall -Wextra -Werror -Wno-unused-parameter -Wno-sign-compare -Wno-unused-function -Wno-unused-variable -Wno-unused-result -Wdeclaration-after-statement
+CFLAGS ?= -g -Wall -Wextra -Werror -Wno-unused-parameter -Wno-sign-compare -Wno-unused-function -Wno-unused-variable -Wno-unused-result -Wdeclaration-after-statement -pedantic
 
 # Uncomment to build XWayland support
 #CFLAGS += -DXWAYLAND

--- a/config.mk
+++ b/config.mk
@@ -3,7 +3,7 @@ PREFIX = /usr/local
 MANDIR = $(PREFIX)/share/man
 
 # Default compile flags (overridable by environment)
-CFLAGS ?= -g -Wall -Wextra -Werror -Wno-unused-parameter -Wno-sign-compare -Wno-unused-function -Wno-unused-variable -Wno-unused-result -Wdeclaration-after-statement -pedantic
+CFLAGS ?= -g -Wall -Wextra -Werror -Wno-unused-parameter -Wno-sign-compare -Wno-unused-function -Wno-unused-variable -Wno-unused-result -Wdeclaration-after-statement
 
 # Uncomment to build XWayland support
 #CFLAGS += -DXWAYLAND

--- a/dwl.c
+++ b/dwl.c
@@ -140,6 +140,7 @@ typedef struct {
 typedef struct {
 	/* Must be first */
 	unsigned int type; /* LayerShell */
+	int mapped;
 	struct wlr_scene_node *scene;
 	struct wl_list link;
 	struct wlr_layer_surface_v1 *layer_surface;
@@ -757,6 +758,12 @@ commitlayersurfacenotify(struct wl_listener *listener, void *data)
 
 	if (!wlr_output || !(m = wlr_output->data))
 		return;
+
+	if (wlr_layer_surface->current.committed == 0
+			&& layersurface->mapped == wlr_layer_surface->mapped)
+		return;
+
+	layersurface->mapped = wlr_layer_surface->mapped;
 
 	if (layers[wlr_layer_surface->current.layer] != layersurface->scene) {
 		wl_list_remove(&layersurface->link);

--- a/dwl.c
+++ b/dwl.c
@@ -1749,9 +1749,9 @@ run(char *startup_cmd)
 	/* Now that the socket exists, run the startup command */
 	if (startup_cmd) {
 		int piperw[2];
-		pipe(piperw);
-		startup_pid = fork();
-		if (startup_pid < 0)
+		if (pipe(piperw) < 0)
+			die("startup: pipe:");
+		if ((startup_pid = fork()) < 0)
 			die("startup: fork:");
 		if (startup_pid == 0) {
 			dup2(piperw[0], STDIN_FILENO);

--- a/dwl.c
+++ b/dwl.c
@@ -1689,9 +1689,7 @@ rendermon(struct wl_listener *listener, void *data)
 			skip = 1;
 		}
 	}
-	if (skip)
-		return;
-	if (!skip && !wlr_scene_output_commit(m->scene_output))
+	if (skip || !wlr_scene_output_commit(m->scene_output))
 		return;
 	/* Let clients know a frame has been rendered */
 	wlr_scene_output_send_frame_done(m->scene_output, &now);

--- a/dwl.c
+++ b/dwl.c
@@ -1689,6 +1689,8 @@ rendermon(struct wl_listener *listener, void *data)
 			skip = 1;
 		}
 	}
+	if (skip)
+		return;
 	if (!skip && !wlr_scene_output_commit(m->scene_output))
 		return;
 	/* Let clients know a frame has been rendered */

--- a/util.c
+++ b/util.c
@@ -1,0 +1,35 @@
+/* See LICENSE.dwm file for copyright and license details. */
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "util.h"
+
+void *
+ecalloc(size_t nmemb, size_t size)
+{
+	void *p;
+
+	if (!(p = calloc(nmemb, size)))
+		die("calloc:");
+	return p;
+}
+
+void
+die(const char *fmt, ...) {
+	va_list ap;
+
+	va_start(ap, fmt);
+	vfprintf(stderr, fmt, ap);
+	va_end(ap);
+
+	if (fmt[0] && fmt[strlen(fmt)-1] == ':') {
+		fputc(' ', stderr);
+		perror(NULL);
+	} else {
+		fputc('\n', stderr);
+	}
+
+	exit(1);
+}

--- a/util.h
+++ b/util.h
@@ -1,0 +1,4 @@
+/* See LICENSE.dwm file for copyright and license details. */
+
+void die(const char *fmt, ...);
+void *ecalloc(size_t nmemb, size_t size);


### PR DESCRIPTION
This fixes the flickering on map/unmap and the 'overshoot' that is visible when map/unmap (and also other times)

I tried to generalize the code a bit since we only care about 'loose' resizes when something is resizing and by extension lfoating. I haven't see the need to check if the clients actually properly resized or not, so I left it out. This will have to be changed if we want to adapt something similar to https://github.com/swaywm/sway/pull/5525(which I doubt)