### PR TITLE
Run printstatus() when a monitor is removed

### DIFF
--- a/dwl.c
+++ b/dwl.c
@@ -740,6 +740,7 @@ closemon(Monitor *m)
 		if (c->mon == m)
 			setmon(c, selmon, c->tags);
 	}
+	printstatus();
 }
 
 void


### PR DESCRIPTION
Windows on the closed monitor will be sent to another monitor, so the status of occupied tags, etc. should be updated to reflect this for external bars.