### PR TITLE
Handle 'wlr_seat_get_keyboard' possibly returning null.

### DIFF
--- a/dwl.c
+++ b/dwl.c
@@ -600,8 +600,11 @@ arrangelayers(Monitor *m)
 					layersurface->layer_surface->mapped) {
 				/* Deactivate the focused client. */
 				focusclient(NULL, 0);
-				wlr_seat_keyboard_notify_enter(seat, layersurface->layer_surface->surface,
-						kb->keycodes, kb->num_keycodes, &kb->modifiers);
+				if (kb) 
+					wlr_seat_keyboard_notify_enter(seat, layersurface->layer_surface->surface,
+							kb->keycodes, kb->num_keycodes, &kb->modifiers);
+				else 
+					wlr_seat_keyboard_notify_enter(seat, layersurface->layer_surface->surface, NULL, 0, NULL);
 				return;
 			}
 		}
@@ -641,7 +644,7 @@ buttonpress(struct wl_listener *listener, void *data)
 			focusclient(c, 1);
 
 		keyboard = wlr_seat_get_keyboard(seat);
-		mods = wlr_keyboard_get_modifiers(keyboard);
+		mods = keyboard ? wlr_keyboard_get_modifiers(keyboard) : 0;
 		for (b = buttons; b < END(buttons); b++) {
 			if (CLEANMASK(mods) == CLEANMASK(b->mod) &&
 					event->button == b->button && b->func) {
@@ -1146,8 +1149,11 @@ focusclient(Client *c, int lift)
 
 	/* Have a client, so focus its top-level wlr_surface */
 	kb = wlr_seat_get_keyboard(seat);
-	wlr_seat_keyboard_notify_enter(seat, client_surface(c),
-			kb->keycodes, kb->num_keycodes, &kb->modifiers);
+	if (kb) 
+		wlr_seat_keyboard_notify_enter(seat, client_surface(c),
+				kb->keycodes, kb->num_keycodes, &kb->modifiers);
+	else 
+		wlr_seat_keyboard_notify_enter(seat, client_surface(c), NULL, 0, NULL);
 
 	/* Activate the new client */
 	client_activate_surface(client_surface(c), 1);


### PR DESCRIPTION
I've gotten segfaults with certain uses of wtype because of dwl not checking if wlr_seat_get_keyboard returns NULL (looks like others also had this issue, see #124 ). This solution handles this case the same way sway handles this.