### PR TITLE
Raise focused client scene to top when switching to monocle layout

### DIFF
--- a/dwl.c
+++ b/dwl.c
@@ -1405,6 +1405,7 @@ monocle(Monitor *m)
 			continue;
 		resize(c, m->w.x, m->w.y, m->w.width, m->w.height, 0);
 	}
+	focusclient(focustop(m), 1);
 }
 
 void


### PR DESCRIPTION
When switching from tile layout to monocle layout, sometimes the window that was focused before ends up under other windows (although still considered focused). If there is a better way to fix this, do tell me, but this does seem to fix the issue.