### PR TITLE
initialize xkb_rules.options to a null pointer

### DIFF
--- a/config.def.h
+++ b/config.def.h
@@ -41,7 +41,7 @@ static const struct xkb_rule_names xkb_rules = {
 	/* example:
 	.options = "ctrl:nocaps",
 	*/
-	.options = "",
+	.options = NULL,
 };
 
 static const int repeat_rate = 25;


### PR DESCRIPTION
Initializing it to an empty string had broken configuring xkbcommon
through the environment (XKB_DEFAULT_OPTIONS).

Fixes: ae313911153b ("initialize rules and xkb_rules")