### PR TITLE
Free pointer focus for seat at end of destroylayersurfacenotify

### DIFF
--- a/dwl.c
+++ b/dwl.c
@@ -1040,6 +1040,11 @@ destroylayersurfacenotify(struct wl_listener *listener, void *data)
 {
 	LayerSurface *layersurface = wl_container_of(listener, layersurface, destroy);
 
+	/* Check if focused_surface saved in the seat pointer_state is the same wlr_surface
+	 * corresponding to this one being destroyed. Clear pointer focus if it is. */
+	if (seat->pointer_state.focused_surface == layersurface->layer_surface->surface)
+		wlr_seat_pointer_notify_clear_focus(seat);
+
 	if (layersurface->layer_surface->mapped)
 		unmaplayersurface(layersurface);
 	wl_list_remove(&layersurface->link);


### PR DESCRIPTION
I've been trying to pin down intermittent crashes while using rofi (for an issue that seems different than #244) and was able to get valgrind to give an error consistently while just opening and closing rofi with the mouse over it:
```
==7671== Invalid write of size 8
==7671==    at 0x4942377: wl_list_remove (wayland-util.c:55)
==7671==    by 0x48C611C: wlr_seat_pointer_enter (wlr_seat_pointer.c:190)
==7671==    by 0x114DD7: pointerfocus (dwl.c:1612)
==7671==    by 0x1148FC: motionnotify (dwl.c:1492)
==7671==    by 0x11421C: maplayersurfacenotify (dwl.c:1369)
==7671==    by 0x48EC1EB: wlr_signal_emit_safe (signal.c:29)
==7671==    by 0x48E5DCD: surface_commit_state (wlr_surface.c:461)
==7671==    by 0x5153E6C: ??? (in /usr/lib/libffi.so.7.1.0)
==7671==    by 0x51532A9: ??? (in /usr/lib/libffi.so.7.1.0)
==7671==    by 0x4941084: wl_closure_invoke.constprop.0 (connection.c:1025)
==7671==    by 0x49450BB: wl_client_connection_data (wayland-server.c:437)
==7671==    by 0x4943C11: wl_event_loop_dispatch (event-loop.c:1027)
==7671==  Address 0x1fd4db48 is 728 bytes inside a block of size 824 free'd
==7671==    at 0x483C0FB: free (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==7671==    by 0x4943ACE: destroy_resource (wayland-server.c:727)
==7671==    by 0x49441C2: UnknownInlinedFun (wayland-util.c:376)
==7671==    by 0x49441C2: UnknownInlinedFun (wayland-util.c:390)
==7671==    by 0x49441C2: wl_client_destroy (wayland-server.c:886)
==7671==    by 0x494462A: UnknownInlinedFun (wayland-server.c:324)
==7671==    by 0x494462A: wl_client_connection_data (wayland-server.c:347)
==7671==    by 0x4943C11: wl_event_loop_dispatch (event-loop.c:1027)
==7671==    by 0x4944364: wl_display_run (wayland-server.c:1408)
==7671==    by 0x11580E: run (dwl.c:1803)
==7671==    by 0x11794E: main (dwl.c:2567)
==7671==  Block was alloc'd at
==7671==    at 0x483E581: calloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==7671==    by 0x48D199D: UnknownInlinedFun (wlr_surface.c:733)
==7671==    by 0x48D199D: compositor_create_surface (wlr_compositor.c:122)
==7671==    by 0x5153E6C: ??? (in /usr/lib/libffi.so.7.1.0)
==7671==    by 0x51532A9: ??? (in /usr/lib/libffi.so.7.1.0)
==7671==    by 0x4941084: wl_closure_invoke.constprop.0 (connection.c:1025)
==7671==    by 0x49450BB: wl_client_connection_data (wayland-server.c:437)
==7671==    by 0x4943C11: wl_event_loop_dispatch (event-loop.c:1027)
==7671==    by 0x4944364: wl_display_run (wayland-server.c:1408)
==7671==    by 0x11580E: run (dwl.c:1803)
==7671==    by 0x11794E: main (dwl.c:2567)
```
The issue appears to be during wlroots trying to remove and reinitialize the surface destroyer for the pointer_state, which still has information left over from the rofi surface after its destruction. So, this addition explicitly clears the pointer focus while destroying a `LayerSurface` object, if that surface is currently focused by the pointer. This seems to fix the issue for me, as I can no longer get the error message from valgrind or this crash from rofi in general.

I don't know if this is the best way to fix this issue, so please do tell me if there's a better way.