### PR TITLE
Fix make install while files are in use

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,10 +56,10 @@ dist: clean
 
 install: dwl
 	mkdir -p $(DESTDIR)$(PREFIX)/bin
-	cp dwl $(DESTDIR)$(PREFIX)/bin
+	cp -f dwl $(DESTDIR)$(PREFIX)/bin
 	chmod 755 $(DESTDIR)$(PREFIX)/bin/dwl
 	mkdir -p $(DESTDIR)$(MANDIR)/man1
-	cp dwl.1 $(DESTDIR)$(MANDIR)/man1
+	cp -f dwl.1 $(DESTDIR)$(MANDIR)/man1
 	chmod 644 $(DESTDIR)$(MANDIR)/man1/dwl.1
 uninstall:
 	rm -f $(DESTDIR)$(PREFIX)/bin/dwl $(DESTDIR)$(MANDIR)/man1/dwl.1


### PR DESCRIPTION
When the dwl executable is in use, `cp` fails with the below error:
```
mkdir -p /usr/local/bin
cp dwl /usr/local/bin
cp: cannot create regular file '/usr/local/bin/dwl': Text file busy
make: *** [Makefile:65: install] Error 1
```

The `-f` flag creates a new file rather than using `open` on the previous file. This way the `dwl` process can still use the original file until it closes it. This appears to be the same behavior used by the `install` command.