### PR TITLE
Highlighting dependencies due to their invisibility.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,9 @@ Feature *non-goals* for the main codebase include:
 
 ## Building dwl
 
-dwl has only two dependencies: wlroots and wayland-protocols. Simply install these (and their `-devel` versions if your distro has separate development packages) and run `make`.  If you wish to build against a Git version of wlroots, check out the [wlroots-next branch](https://github.com/djpohly/dwl/tree/wlroots-next).
+dwl has only two dependencies: `wlroots` and `wayland-protocols`. 
+
+Simply install these (and their `-devel` versions if your distro has separate development packages) and run `make`.  If you wish to build against a Git version of wlroots, check out the [wlroots-next branch](https://github.com/djpohly/dwl/tree/wlroots-next).
 
 To enable XWayland, you should also install xorg-xwayland and uncomment its flag in `config.mk`.
 


### PR DESCRIPTION
It's hard to see which dependencies are needed.