### PR TITLE
Fix segfault if parent->mon is unset

### DIFF
--- a/dwl.c
+++ b/dwl.c
@@ -1437,7 +1437,8 @@ mapnotify(struct wl_listener *listener, void *data)
 		/* Set the same monitor and tags than its parent */
 		c->isfloating = 1;
 		wlr_scene_node_reparent(c->scene, layers[LyrFloat]);
-		setmon(c, p->mon, p->tags);
+		/* TODO recheck if !p->mon is possible with wlroots 0.16.0 */
+		setmon(c, p->mon ? p->mon : selmon, p->tags);
 	} else {
 		applyrules(c);
 	}


### PR DESCRIPTION
I don't know why, but since 90a12c9, mtpaint triggers a crash: c->mon is NULL after mapnotify(). This application has two windows, a main window and a small window with drawing tools.

This application hardcodes GDK_BACKEND=x11, so it's built with a patch (https://github.com/puppylinux-woof-CE/woof-CE/blob/testing/woof-code/rootfs-petbuilds/mtpaint/wayland.patch).