### PR TITLE
Implement wlr_relative_pointer_manager_v1

### DIFF
--- a/dwl.c
+++ b/dwl.c
@@ -36,6 +36,7 @@
 #include <wlr/types/wlr_presentation_time.h>
 #include <wlr/types/wlr_primary_selection.h>
 #include <wlr/types/wlr_primary_selection_v1.h>
+#include <wlr/types/wlr_relative_pointer_v1.h>
 #include <wlr/types/wlr_scene.h>
 #include <wlr/types/wlr_screencopy_v1.h>
 #include <wlr/types/wlr_seat.h>
@@ -319,6 +320,7 @@ static struct wlr_input_inhibit_manager *input_inhibit_mgr;
 static struct wlr_layer_shell_v1 *layer_shell;
 static struct wlr_output_manager_v1 *output_mgr;
 static struct wlr_virtual_keyboard_manager_v1 *virtual_keyboard_mgr;
+static struct wlr_relative_pointer_manager_v1 *rel_ptr_mgr;
 
 static struct wlr_cursor *cursor;
 static struct wlr_xcursor_manager *cursor_mgr;
@@ -1526,6 +1528,10 @@ motionrelative(struct wl_listener *listener, void *data)
 	/* This event is forwarded by the cursor when a pointer emits a _relative_
 	 * pointer motion event (i.e. a delta) */
 	struct wlr_event_pointer_motion *event = data;
+
+	wlr_relative_pointer_manager_v1_send_relative_motion(rel_ptr_mgr, seat, event->time_msec * 1000,
+		event->delta_x, event->delta_y, event->unaccel_dx, event->unaccel_dy);
+
 	/* The cursor doesn't move unless we tell it to. The cursor automatically
 	 * handles constraining the motion to the output layout, as well as any
 	 * special configuration applied for the specific input device which
@@ -2085,6 +2091,8 @@ setup(void)
 	 * images are available at all scale factors on the screen (necessary for
 	 * HiDPI support). Scaled cursors will be loaded with each output. */
 	cursor_mgr = wlr_xcursor_manager_create(NULL, 24);
+
+	rel_ptr_mgr = wlr_relative_pointer_manager_v1_create(dpy);
 
 	/*
 	 * wlr_cursor *only* displays an image on screen. It does not move around


### PR DESCRIPTION
This makes games such as Minecraft function properly. As is, moving the mouse causes some spiraling behavior which makes the game unplayable. This implementation is similar to that of Sway's.