### PR TITLE
check null popup->parent

### DIFF
--- a/client.h
+++ b/client.h
@@ -304,7 +304,7 @@ toplevel_from_popup(struct wlr_xdg_popup *popup)
 	while (1) {
 		switch (surface->role) {
 		case WLR_XDG_SURFACE_ROLE_POPUP:
-			if (surface->popup->parent == NULL)
+			if (!surface->popup->parent)
 				return NULL;
 			else if (wlr_surface_is_layer_surface(surface->popup->parent))
 				return wlr_layer_surface_v1_from_wlr_surface(surface->popup->parent)->data;

--- a/client.h
+++ b/client.h
@@ -304,7 +304,9 @@ toplevel_from_popup(struct wlr_xdg_popup *popup)
 	while (1) {
 		switch (surface->role) {
 		case WLR_XDG_SURFACE_ROLE_POPUP:
-			if (wlr_surface_is_layer_surface(surface->popup->parent))
+			if (surface->popup->parent == NULL)
+				return NULL;
+			else if (wlr_surface_is_layer_surface(surface->popup->parent))
 				return wlr_layer_surface_v1_from_wlr_surface(surface->popup->parent)->data;
 			else if (!wlr_surface_is_xdg_surface(surface->popup->parent))
 				return NULL;

--- a/dwl.c
+++ b/dwl.c
@@ -1016,6 +1016,8 @@ createnotify(struct wl_listener *listener, void *data)
 	if (xdg_surface->role == WLR_XDG_SURFACE_ROLE_POPUP) {
 		struct wlr_box box;
 		LayerSurface *l = toplevel_from_popup(xdg_surface->popup);
+		if (xdg_surface->popup->parent == NULL)
+			return;
 		xdg_surface->surface->data = wlr_scene_xdg_surface_create(
 				xdg_surface->popup->parent->data, xdg_surface);
 		/* Probably the check of `l` is useless, the only thing that can be NULL

--- a/dwl.c
+++ b/dwl.c
@@ -1016,7 +1016,7 @@ createnotify(struct wl_listener *listener, void *data)
 	if (xdg_surface->role == WLR_XDG_SURFACE_ROLE_POPUP) {
 		struct wlr_box box;
 		LayerSurface *l = toplevel_from_popup(xdg_surface->popup);
-		if (xdg_surface->popup->parent == NULL)
+		if (!xdg_surface->popup->parent)
 			return;
 		xdg_surface->surface->data = wlr_scene_xdg_surface_create(
 				xdg_surface->popup->parent->data, xdg_surface);


### PR DESCRIPTION
managed to SEGFAULT the server by trying to create a popup without setting a parent first.

Not sure if this is dwl or wlroots issue, so also opened a ticket upstream: https://gitlab.freedesktop.org/wlroots/wlroots/-/merge_requests/3811