### PR TITLE
Check that inhibitor scene tree is not null

### DIFF
--- a/dwl.c
+++ b/dwl.c
@@ -598,7 +598,7 @@ checkidleinhibitor(struct wlr_surface *exclude)
 	wl_list_for_each(inhibitor, &idle_inhibit_mgr->inhibitors, link) {
 		struct wlr_scene_tree *tree = inhibitor->surface->data;
 		if (bypass_surface_visibility || (exclude != inhibitor->surface
-				&& tree->node.enabled)) {
+				&& tree && tree->node.enabled)) {
 			inhibited = 1;
 			break;
 		}


### PR DESCRIPTION
I get a segfault when trying to share video on zoom through firefox (with `bypass_surface_visibility` set to 0). Backtrace below:

```
#0  0x000055555555c3ac in checkidleinhibitor (exclude=exclude@entry=0x0) at dwl.c:600
        tree = 0x0
        inhibited = 0
        inhibitor = 0x555555dce810
#1  0x000055555555c402 in createidleinhibitor (listener=<optimized out>, data=<optimized out>) at dwl.c:749
        idle_inhibitor = <optimized out>
#2  0x00007ffff7e9047c in wl_signal_emit_mutable (signal=<optimized out>, data=0x555555dce810) at ../src/wayland-server.c:2179
        pos = 0x555555565e90 <idle_inhibitor_create>
        l = 0x555555565e90 <idle_inhibitor_create>
        cursor = {link = {prev = 0x555555565e90 <idle_inhibitor_create>, next = 0x7fffffffd590}, notify = 0x7ffff7e8d740 <handle_noop>}
        end = {link = {prev = 0x7fffffffd5b0, next = 0x555555d7e6c0}, notify = 0x7ffff7e8d740 <handle_noop>}
#3  0x00007ffff7885e6d in ?? () from /usr/lib/libffi.so.7
No symbol table info available.
#4  0x00007ffff78852aa in ?? () from /usr/lib/libffi.so.7
No symbol table info available.
#5  0x00007ffff7e8f0b5 in wl_closure_invoke (closure=closure@entry=0x555555f0dde0, target=<optimized out>, target@entry=0x555555da9220, opcode=opcode@entry=1, data=<optimized out>, 
    data@entry=0x55555563a530, flags=<optimized out>) at ../src/connection.c:1025
        count = <optimized out>
        cif = {abi = FFI_UNIX64, nargs = 4, arg_types = 0x7fffffffd760, rtype = 0x7ffff7887180 <ffi_type_void>, bytes = 0, flags = 0}
        ffi_types = {0x7ffff7887060 <ffi_type_pointer>, 0x7ffff7887060 <ffi_type_pointer>, 0x7ffff78870e0 <ffi_type_uint32>, 0x7ffff7887060 <ffi_type_pointer>, 0x7fff00000002, 
          0x7fffffffd7a8, 0x7fffffffd870, 0x7fffffffd700, 0xf0, 0x1, 0x7fff00000001, 0x555555f1a3f0, 0x0, 0x308979f2031c1700, 0x7ffff7887060 <ffi_type_pointer>, 0x555555f1a3f0, 
          0x7fffffffd840, 0x2, 0xd, 0x7, 0xf0, 0xe0}
        ffi_args = {0x7fffffffd720, 0x7fffffffd728, 0x555555f0ddf8, 0x555555f0de00, 0x330000000f, 0x0, 0x0, 0x0, 0x770000005b, 0x7ffff7e90980 <log_closure+80>, 
          0x7ffff7887060 <ffi_type_pointer>, 0x555555577440, 0x7ffff7de3a00 <main_arena>, 0xe0, 0x555555f26ab0, 0x2, 0x555555f1e950, 0x7ffff7caf741 <__libc_calloc+129>, 0x0, 0x7ffff7f9ab38, 
          0x7ffff7f662bc, 0x100001}
        implementation = <optimized out>
#6  0x00007ffff7e932dc in wl_client_connection_data (fd=<optimized out>, mask=<optimized out>, data=<optimized out>) at ../src/wayland-server.c:437
        client = <optimized out>
        connection = 0x555555f1e950
        resource = <optimized out>
        object = 0x555555da9220
        closure = 0x555555f0dde0
        message = 0x7ffff7f9ab38
        p = {44, 1048577}
        resource_flags = 0
        opcode = 1
        size = <optimized out>
        since = <optimized out>
        len = <optimized out>
#7  0x00007ffff7e91e22 in wl_event_loop_dispatch (loop=0x555555577530, timeout=timeout@entry=-1) at ../src/event-loop.c:1027
        ep = {{events = 1, data = {ptr = 0x555555dcc890, fd = 1440532624, u32 = 1440532624, u64 = 93825001113744}}, {events = 1, data = {ptr = 0x555555dcc890, fd = 1440532624, 
              u32 = 1440532624, u64 = 93825001113744}}, {events = 52172544, data = {ptr = 0x3f800000308979f2, fd = 814316018, u32 = 814316018, u64 = 4575657222222739954}}, {events = 0, 
            data = {ptr = 0x555555f1e950, fd = 1441917264, u32 = 1441917264, u64 = 93825002498384}}, {events = 4294957952, data = {ptr = 0x1800007fff, fd = 32767, u32 = 32767, 
              u64 = 103079247871}}, {events = 0, data = {ptr = 0x555555f21968, fd = 1441929576, u32 = 1441929576, u64 = 93825002510696}}, {events = 1441921368, data = {ptr = 0x100005555, 
              fd = 21845, u32 = 21845, u64 = 4294989141}}, {events = 0, data = {ptr = 0x7ffff7e8eadf <wl_connection_flush+319>, fd = -135730465, u32 = 4159236831, u64 = 140737352624863}}, {
            events = 1103101952, data = {ptr = 0x1800000000, fd = 0, u32 = 0, u64 = 103079215104}}, {events = 0, data = {ptr = 0x7fffffffdbc0, fd = -9280, u32 = 4294958016, 
              u64 = 140737488346048}}, {events = 0, data = {ptr = 0x1ebac, fd = 125868, u32 = 125868, u64 = 125868}}, {events = 0, data = {ptr = 0x0, fd = 0, u32 = 0, u64 = 0}}, {
            events = 0, data = {ptr = 0x0, fd = 0, u32 = 0, u64 = 0}}, {events = 0, data = {ptr = 0x0, fd = 0, u32 = 0, u64 = 0}}, {events = 0, data = {ptr = 0x0, fd = 0, u32 = 0, 
              u64 = 0}}, {events = 0, data = {ptr = 0x0, fd = 0, u32 = 0, u64 = 0}}, {events = 1441924356, data = {ptr = 0x1800005555, fd = 21845, u32 = 21845, u64 = 103079236949}}, {
            events = 0, data = {ptr = 0x555555f1f958, fd = 1441921368, u32 = 1441921368, u64 = 93825002502488}}, {events = 16, data = {ptr = 0x1400000000, fd = 0, u32 = 0, u64 = 85899345920}}, {events = 0, data = {ptr = 0x100000001, fd = 1, u32 = 1, u64 = 4294967297}}, {events = 40, data = {ptr = 0xf7eff65800000026, fd = 38, u32 = 38, u64 = 17865769104619601958}}, {events = 24, data = {ptr = 0x4059000000000000, fd = 0, u32 = 0, u64 = 4636737291354636288}}, {events = 1440030704, data = {ptr = 0x55dee97000005555, fd = 21845, u32 = 21845, u64 = 6187639605299270997}}, {events = 21845, data = {ptr = 0x60, fd = 96, u32 = 96, u64 = 96}}, {events = 24, data = {ptr = 0x1800000000, fd = 0, u32 = 0, u64 = 103079215104}}, {events = 0, data = {ptr = 0x4, fd = 4, u32 = 4, u64 = 4}}, {events = 4159806167, data = {ptr = 0x400007fff, fd = 32767, u32 = 32767, u64 = 17179901951}}, {events = 0, data = {ptr = 0x308979f2031c1700, fd = 52172544, u32 = 52172544, u64 = 3497460665971119872}}, {events = 1440213616, data = {ptr = 0x3f80000000005555, fd = 21845, u32 = 21845, u64 = 4575657221408445781}}, {events = 16799061, data = {ptr = 0x555555d7ea70, fd = 1440213616, u32 = 1440213616, u64 = 93825000794736}}, {events = 52172544, data = {ptr = 0x55d73ee0308979f2, fd = 814316018, u32 = 814316018, u64 = 6185481745824578034}}, {events = 21845, data = {ptr = 0x555555577468, fd = 1431794792, u32 = 1431794792, u64 = 93824992375912}}}
        source = <optimized out>
        i = 0
        count = <optimized out>
        has_timers = <optimized out>
#8  0x00007ffff7e92575 in wl_display_run (display=0x555555577440) at ../src/wayland-server.c:1431
No locals.
#9  0x00005555555605e3 in run (startup_cmd=0x0) at dwl.c:1808
        socket = 0x555555d7f2e9 "wayland-1"
        socket = <optimized out>
        piperw = <optimized out>
#10 main (argc=1, argv=<optimized out>) at dwl.c:2624
        startup_cmd = 0x0
        c = <optimized out>
```

I don't know if we expect `inhibitor->surface->data` to be non-null always, in which case it may be more complicated than this to fix.