### PR TITLE
Fix null deref in sigchld() if Xwayland is disabled

### DIFF
--- a/dwl.c
+++ b/dwl.c
@@ -2564,7 +2564,7 @@ sigchld(int unused)
 	 * XWayland process
 	 */
 	while (!waitid(P_ALL, 0, &in, WEXITED|WNOHANG|WNOWAIT) && in.si_pid
-			&& in.si_pid != xwayland->server->pid)
+			&& (!xwayland || in.si_pid != xwayland->server->pid))
 		waitpid(in.si_pid, NULL, 0);
 }
 


### PR DESCRIPTION
(Heavily patched dwl that doesn't start Xwayland and segfaults when it runs with `-k`)

```
==6318==ERROR: AddressSanitizer: SEGV on unknown address 0x000000000000 (pc 0x55c26478a5ca bp 0x7ffe8aaa46b0 sp 0x7ffe8aaa45c0 T0)
==6318==The signal is caused by a READ memory access.
==6318==Hint: address points to the zero page.
    #0 0x55c26478a5ca in sigchld /root/dwl/dwl.c:3118
    #1 0x7f587b403f8f  (/lib/x86_64-linux-gnu/libc.so.6+0x3bf8f)
```

```
                        && in.si_pid != xwayland->server->pid)
```