### PR TITLE
Check width and height are not negative in client_set_bounds()

### DIFF
--- a/client.h
+++ b/client.h
@@ -141,7 +141,7 @@ client_set_bounds(Client *c, int32_t width, int32_t height)
 		return 0;
 #endif
 	if (c->surface.xdg->client->shell->version >=
-			XDG_TOPLEVEL_CONFIGURE_BOUNDS_SINCE_VERSION)
+			XDG_TOPLEVEL_CONFIGURE_BOUNDS_SINCE_VERSION && width >= 0 && height >= 0)
 		return wlr_xdg_toplevel_set_bounds(c->surface.xdg->toplevel, width, height);
 	return 0;
 }


### PR DESCRIPTION
`wlr_xdg_toplevel_set_bounds()` asserts width and height >= 0, so if you attempt to resize a native wayland window too far left or up ending up with a negative height or width, dwl crashes with a `SIGABRT`. 