### PR TITLE
Remove rootcolor

### DIFF
--- a/config.def.h
+++ b/config.def.h
@@ -2,7 +2,6 @@
 static const int sloppyfocus               = 1;  /* focus follows mouse */
 static const int bypass_surface_visibility = 0;  /* 1 means idle inhibitors will disable idle tracking even if it's surface isn't visible  */
 static const unsigned int borderpx         = 1;  /* border pixel of windows */
-static const float rootcolor[]             = {0.3, 0.3, 0.3, 1.0};
 static const float bordercolor[]           = {0.5, 0.5, 0.5, 1.0};
 static const float focuscolor[]            = {1.0, 0.0, 0.0, 1.0};
 /* To conform the xdg-protocol, set the alpha to zero to restore the old behavior */


### PR DESCRIPTION
rootcolor hasn't been in use since we switched to the new renderer.