### PR TITLE
focused borders on active client after lockscreen

### DIFF
--- a/dwl.c
+++ b/dwl.c
@@ -2435,6 +2435,7 @@ unlocksession(struct wl_listener *listener, void *data)
 {
 	SessionLock *lock = wl_container_of(listener, lock, unlock);
 	destroylock(lock, 1);
+	arrangelayers(selmon);
 }
 
 void


### PR DESCRIPTION
After locking the screen the active client no longer has focus indicated by focuscolor borders. This patch ensures the exclusive_focus variable is set so focuscolor borders are applied to the active client.