### PR TITLE
remove tag labels from dwl

### DIFF
--- a/config.def.h
+++ b/config.def.h
@@ -7,8 +7,8 @@ static const float focuscolor[]            = {1.0, 0.0, 0.0, 1.0};
 /* To conform the xdg-protocol, set the alpha to zero to restore the old behavior */
 static const float fullscreen_bg[]         = {0.1, 0.1, 0.1, 1.0};
 
-/* tagging */
-static const char *tags[] = { "1", "2", "3", "4", "5", "6", "7", "8", "9" };
+/* tagging - tagcount should be no greater than 31 */
+static const int tagcount = 9;
 
 static const Rule rules[] = {
 	/* app_id     title       tags mask     isfloating   monitor */

--- a/dwl.c
+++ b/dwl.c
@@ -67,7 +67,7 @@
 #define VISIBLEON(C, M)         ((M) && (C)->mon == (M) && ((C)->tags & (M)->tagset[(M)->seltags]))
 #define LENGTH(X)               (sizeof X / sizeof X[0])
 #define END(A)                  ((A) + LENGTH(A))
-#define TAGMASK                 ((1 << LENGTH(tags)) - 1)
+#define TAGMASK                 ((1u << tagcount) - 1)
 #define LISTEN(E, L, H)         wl_signal_add((E), ((L)->notify = (H), (L)))
 #define IDLE_NOTIFY_ACTIVITY    wlr_idle_notify_activity(idle, seat), wlr_idle_notifier_v1_notify_activity(idle_notifier, seat)
 
@@ -410,9 +410,6 @@ static Atom netatom[NetLast];
 
 /* attempt to encapsulate suck into one file */
 #include "client.h"
-
-/* compile-time check if all tags fit into an unsigned int bit array. */
-struct NumTags { char limitexceeded[LENGTH(tags) > 31 ? -1 : 1]; };
 
 /* function implementations */
 void


### PR DESCRIPTION
Tag labels are not used in dwl. Only the number of tags is important. Tag labels should be defined for each tag in whatever status bar is used.

Also tag mask should be an unsigned int so that documented limit of 31 tags does not cause an integer overflow.