### PR TITLE
Prevent using a wlr_layer_surface after destroying it

### DIFF
--- a/dwl.c
+++ b/dwl.c
@@ -836,8 +836,10 @@ createlayersurface(struct wl_listener *listener, void *data)
 	if (!wlr_layer_surface->output)
 		wlr_layer_surface->output = selmon ? selmon->wlr_output : NULL;
 
-	if (!wlr_layer_surface->output)
+	if (!wlr_layer_surface->output) {
 		wlr_layer_surface_v1_destroy(wlr_layer_surface);
+		return;
+	}
 
 	layersurface = ecalloc(1, sizeof(LayerSurface));
 	layersurface->type = LayerShell;


### PR DESCRIPTION
If the `createlayersurface` callback is hit when `selmon` is NULL then `wlr_layer_surface` is destroyed by calling `wlr_layer_surface_v1_destroy()`. This change simply adds a return at that point, to prevent a crash caused by dereferencing the destroyed variable.

The crash in question can be reproduced easily by unplugging or turning off all monitors while running `swaync`, waiting a few seconds and then plugging them back in. It is likely possible to cause this with things other than `swaync`, but that was the application that triggered it for me.