### PR TITLE
activate lock surface in updatemons

### DIFF
--- a/dwl.c
+++ b/dwl.c
@@ -2572,9 +2572,12 @@ updatemons(struct wl_listener *listener, void *data)
 		wl_list_for_each(c, &clients, link)
 			if (!c->mon && client_is_mapped(c))
 				setmon(c, selmon, c->tags);
-		if (selmon->lock_surface)
+		focusclient(focustop(selmon), 1);
+		if (selmon->lock_surface) {
 			client_notify_enter(selmon->lock_surface->surface,
 					wlr_seat_get_keyboard(seat));
+			client_activate_surface(selmon->lock_surface->surface, 1);
+		}
 	}
 
 	wlr_output_manager_v1_set_configuration(output_mgr, config);


### PR DESCRIPTION
Fixes an issue when swaylock does not receive input after turn off and then turn on the outputs