### PR TITLE
Set XCURSOR_SIZE to fix cursor changing size

### DIFF
--- a/dwl.c
+++ b/dwl.c
@@ -2254,6 +2254,7 @@ setup(void)
 	 * images are available at all scale factors on the screen (necessary for
 	 * HiDPI support). Scaled cursors will be loaded with each output. */
 	cursor_mgr = wlr_xcursor_manager_create(NULL, 24);
+	setenv("XCURSOR_SIZE", "24", 1);
 
 	/*
 	 * wlr_cursor *only* displays an image on screen. It does not move around


### PR DESCRIPTION
When I hover a cursor over various clients, the cursor changes its size. For example, it's normal size on foot and becomes bigger in qutebrowser. I figured out that these clients use `XCURSOR_SIZE` env variable to determine appropriate cursor size and when it's unset, they fallback to using some default value. I presume this default is not the same on all clients, this is why cursor size changes. This PR adds a `setenv` call to make sure `XCURSOR_SIZE` is set to the proper value.