### PR TITLE
fix startup_cmd SIGCHLD handler

### DIFF
--- a/dwl.c
+++ b/dwl.c
@@ -2327,6 +2327,9 @@ void
 spawn(const Arg *arg)
 {
 	if (fork() == 0) {
+		struct sigaction sa = {.sa_flags = SA_RESTART, .sa_handler = SIG_DFL};
+		sigemptyset(&sa.sa_mask);
+		sigaction(SIGCHLD, &sa, NULL);
 		dup2(STDERR_FILENO, STDOUT_FILENO);
 		setsid();
 		execvp(((char **)arg->v)[0], (char **)arg->v);

--- a/dwl.c
+++ b/dwl.c
@@ -1963,6 +1963,8 @@ run(char *startup_cmd)
 		if ((child_pid = fork()) < 0)
 			die("startup: fork:");
 		if (child_pid == 0) {
+			sa.sa_handler = SIG_DFL;
+			sigaction(SIGCHLD, &sa, NULL);
 			dup2(piperw[0], STDIN_FILENO);
 			close(piperw[0]);
 			close(piperw[1]);


### PR DESCRIPTION
Looks like ignored signals aren't reset by `exec()` calls.  If the startup command needs to fork and wait on child processes (e.g. a session manager like s6-svscan), the `SIG_IGN` that is still in place will interfere with waiting.