### PR TITLE
Make fibonacci patch work

### DIFF
--- a/config.def.h
+++ b/config.def.h
@@ -24,6 +24,8 @@ static const Layout layouts[] = {
 	{ "[]=",      tile },
 	{ "><>",      NULL },    /* no layout function means floating behavior */
 	{ "[M]",      monocle },
+	{ "[@]",      spiral },
+	{ "[\\]",      dwindle },
 };
 
 /* monitors */

--- a/dwl.c
+++ b/dwl.c
@@ -272,6 +272,8 @@ static void maplayersurfacenotify(struct wl_listener *listener, void *data);
 static void mapnotify(struct wl_listener *listener, void *data);
 static void maximizenotify(struct wl_listener *listener, void *data);
 static void monocle(Monitor *m);
+static void dwindle(Monitor *mon);
+static void spiral(Monitor *mon);
 static void motionabsolute(struct wl_listener *listener, void *data);
 static void motionnotify(uint32_t time);
 static void motionrelative(struct wl_listener *listener, void *data);
@@ -1613,6 +1615,76 @@ monocle(Monitor *m)
 		snprintf(m->ltsymbol, LENGTH(m->ltsymbol), "[%d]", n);
 	if ((c = focustop(m)))
 		wlr_scene_node_raise_to_top(&c->scene->node);
+}
+
+void fibonacci(Monitor *mon, int s) {
+	unsigned int i=0, n=0, nx, ny, nw, nh;
+	Client *c;
+
+	wl_list_for_each(c, &clients, link)
+		if (VISIBLEON(c, mon) && !c->isfloating)
+			n++;
+	if(n == 0)
+		return;
+
+	nx = mon->w.x;
+	ny = 0;
+	nw = mon->w.width;
+	nh = mon->w.height;
+
+	wl_list_for_each(c, &clients, link)
+		if (VISIBLEON(c, mon) && !c->isfloating){
+		if((i % 2 && nh / 2 > 2 * c->bw)
+		   || (!(i % 2) && nw / 2 > 2 * c->bw)) {
+			if(i < n - 1) {
+				if(i % 2)
+					nh /= 2;
+				else
+					nw /= 2;
+				if((i % 4) == 2 && !s)
+					nx += nw;
+				else if((i % 4) == 3 && !s)
+					ny += nh;
+			}
+			if((i % 4) == 0) {
+				if(s)
+					ny += nh;
+				else
+					ny -= nh;
+			}
+			else if((i % 4) == 1)
+				nx += nw;
+			else if((i % 4) == 2)
+				ny += nh;
+			else if((i % 4) == 3) {
+				if(s)
+					nx += nw;
+				else
+					nx -= nw;
+			}
+			if(i == 0)
+			{
+				if(n != 1)
+					nw = mon->w.width * mon->mfact;
+				ny = mon->w.y;
+			}
+			else if(i == 1)
+				nw = mon->w.width - nw;
+			i++;
+		}
+		resize(c, (struct wlr_box){.x = nx, .y = ny,
+			.width = nw - 2 * c->bw, .height = nh - 2 * c->bw}, 0);
+	}
+}
+
+void
+dwindle(Monitor *mon) {
+	fibonacci(mon, 1);
+}
+
+void
+spiral(Monitor *mon) {
+	fibonacci(mon, 0);
 }
 
 void


### PR DESCRIPTION
This makes the original fibonacci patch work.

It add the dwindle() function, spiral() function, fibonacci() function to the main dwl.c file instead of messing with the config.def.h and Makefile, and makes the patch actually compile.