### PR TITLE
Fixed Typo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ DWLDEVCFLAGS = -pedantic -Wall -Wextra -Wdeclaration-after-statement -Wno-unused
 # CFLAGS / LDFLAGS
 PKGS      = wlroots wayland-server xkbcommon libinput $(XLIBS)
 DWLCFLAGS = `$(PKG_CONFIG) --cflags $(PKGS)` $(DWLCPPFLAGS) $(DWLDEVCFLAGS) $(CFLAGS)
-LDLIBS    = `$(PKG_CONFIG) --libs $(PKGS)` $(LIBS)
+LDLIBS    = `$(PKG_CONFIG) --libs $(PKGS) $(LIBS)`
 
 all: dwl
 dwl: dwl.o util.o


### PR DESCRIPTION
The backtick symbol was at the wrong position.
If you wanted to compile with XWayland support 
(by commenting according lines out in config.mk),
you'd run into an error.