### PR TITLE
Fix tiling order for X11 clients

### DIFF
--- a/dwl.c
+++ b/dwl.c
@@ -2679,8 +2679,6 @@ zoom(const Arg *arg)
 	 * front */
 	if (!sel)
 		sel = c;
-	wl_list_remove(&sel->link);
-	wl_list_insert(&clients, &sel->link);
 
 	focusclient(sel, 1);
 	arrange(selmon);


### PR DESCRIPTION
Currently, Wayland clients are tiled in the correct order, but clients running under XWayland are not. To see this in action, spawn (for example) st, chromium and st and observe that the visible tiling order is st, st, chromium.

Applying this patch fixes this behavior.