### PR TITLE
check client is mapped before setting border color

### DIFF
--- a/dwl.c
+++ b/dwl.c
@@ -2593,7 +2593,8 @@ urgent(struct wl_listener *listener, void *data)
 	if (!c || c == focustop(selmon))
 		return;
 
-	client_set_border_color(c, urgentcolor);
+	if (client_is_mapped(c))
+		client_set_border_color(c, urgentcolor);
 	c->isurgent = 1;
 	printstatus();
 }


### PR DESCRIPTION
For some reason brave configured for as a wayland client triggers this code on startup and segfaults.

Checking if the client is mapped fixes this, like with the previous fix for urgent border colour.