### PR TITLE
createkeyboard: do not segfault if xkb_keymap_new_from_names returns NULL

### DIFF
--- a/dwl.c
+++ b/dwl.c
@@ -802,6 +802,8 @@ createkeyboard(struct wlr_keyboard *keyboard)
 	context = xkb_context_new(XKB_CONTEXT_NO_FLAGS);
 	keymap = xkb_keymap_new_from_names(context, &xkb_rules,
 		XKB_KEYMAP_COMPILE_NO_FLAGS);
+	if (!keymap)
+		die("createkeyboard: failed to compile keymap");
 
 	wlr_keyboard_set_keymap(keyboard, keymap);
 	xkb_keymap_unref(keymap);


### PR DESCRIPTION
Passing NULL to wlr_keyboard_set_keymap results in a segfault.
Example:

```
  Thread 1 "dwl" received signal SIGSEGV, Segmentation fault.
  0x00007ffff7e49b64 in xkb_keymap_ref () from /usr/lib/libxkbcommon.so.0
  (gdb) bt
  #0  0x00007ffff7e49b64 in xkb_keymap_ref () at /usr/lib/libxkbcommon.so.0
  #1  0x00007ffff7f06389 in wlr_keyboard_set_keymap () at /usr/lib/libwlroots.so.11
  #2  0x000055555555bc54 in createkeyboard ()
  #3  0x000055555555c283 in inputdevice ()
  #4  0x00007ffff7e8101e in wl_signal_emit_mutable () at /usr/lib/libwayland-server.so.0
  #5  0x00007ffff7e8101e in wl_signal_emit_mutable () at /usr/lib/libwayland-server.so.0
  #6  0x00007ffff7edb52c in  () at /usr/lib/libwlroots.so.11
  #7  0x00007ffff7ee44b6 in  () at /usr/lib/libwlroots.so.11
  #8  0x000055555555fe66 in main ()
```